### PR TITLE
Add dependencies to `publish` GH action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,9 +28,11 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GH_SELFHOSTEDRESOURCES_RW }}"
 
-      - name: Add NVIDIA Helm chart repository
+      - name: Add Helm chart repositories for chart dependencies
         run: |
           helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add autoscaler https://kubernetes.github.io/autoscaler
           helm repo update
 
       - name: Run chart-releaser


### PR DESCRIPTION
At this time, the `helm/chart-releaser-action` doesn't automatically add the required Helm repositories, for security reasons. We need to manually add the needed repositories before running the action.