### PR TITLE
Reload deployments when underlying configmaps change

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.1-beta] - 2024-06-24
 
-*Nothing at this time*
+### Added
+
+- Restart Deepgram containers automatically when underlying ConfigMaps have been modified.
 
 ## [0.2.0-beta] - 2024-06-20
 
@@ -36,7 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Initial implementation of the Helm chart.
 
 
-[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.1.1-alpha...HEAD
+[0.2.1-beta]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.2.0-beta...deepgram-self-hosted-0.2.1-beta
 [0.2.0-beta]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.1.1-alpha...deepgram-self-hosted-0.2.0-beta
 [0.1.1-alpha]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.1.0-alpha...deepgram-self-hosted-0.1.1-alpha
 [0.1.0-alpha]: https://github.com/deepgram/self-hosted-resources/releases/tag/deepgram-self-hosted-0.1.0-alpha

--- a/charts/deepgram-self-hosted/Chart.yaml
+++ b/charts/deepgram-self-hosted/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: deepgram-self-hosted
 type: application
-version: 0.2.0-beta
+version: 0.2.1-beta
 appVersion: "release-240528"
 description: A Helm chart for running Deepgram services in a self-hosted environment
 home: "https://developers.deepgram.com/docs/self-hosted-introduction"

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -1,6 +1,6 @@
 # deepgram-self-hosted
 
-![Version: 0.2.0-beta](https://img.shields.io/badge/Version-0.2.0--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-240528](https://img.shields.io/badge/AppVersion-release--240528-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
+![Version: 0.2.1-beta](https://img.shields.io/badge/Version-0.2.1--beta-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-240528](https://img.shields.io/badge/AppVersion-release--240528-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
 
 A Helm chart for running Deepgram services in a self-hosted environment
 

--- a/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
@@ -22,6 +22,8 @@ spec:
   template:
     metadata:
       labels: *labels
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/api/api.config.yaml") . | sha256sum }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.global.outstandingRequestGracePeriod }}
       imagePullSecrets:

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -22,6 +22,8 @@ spec:
   template:
     metadata:
       labels: *labels
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/engine/engine.config.yaml") . | sha256sum }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.global.outstandingRequestGracePeriod }}
       imagePullSecrets:

--- a/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
@@ -23,6 +23,8 @@ spec:
   template:
     metadata:
       labels: *labels
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/license-proxy/license-proxy.config.yaml") . | sha256sum }}
     spec:
       imagePullSecrets:
       - name: {{ required "Missing image repository credentials - see `global.pullSecretRef`" .Values.global.pullSecretRef }}


### PR DESCRIPTION
API, Engine, and License Proxy containers require a container restart in order to load a new set of configuration values.

This change adjusts the Helm chart to automatically restart these containers if the underlying ConfigMap has changed. See [Helm docs](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments) for details.