### PR TITLE
Make image pull secret optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -20,9 +20,9 @@ jobs:
         run: helm lint ./charts/deepgram-self-hosted
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.17
+          go-version: 1.22
 
       - name: Install helm-docs
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: "${{ secrets.GH_SELFHOSTEDRESOURCES_RW }}"

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -36,7 +36,7 @@ helm repo update
 
 The Deepgram self-hosted chart requires Helm 3.7+ in order to install successfully. Please check your helm release before installation.
 
-You will need to provide your [self-service Deepgram licensing and credentials](https://developers.deepgram.com/docs/on-prem-self-service-tutorial) information. See `global.deepgramSecretRef` and `global.pullSecretRef` in the [Values section](#values) for more details.
+You will need to provide your [self-service Deepgram licensing and credentials](https://developers.deepgram.com/docs/on-prem-self-service-tutorial) information. See `global.deepgramSecretRef` and `global.pullSecretRef` in the [Values section](#values) for more details, and the [Deepgram Self-Hosted Kubernetes Guides](https://developers.deepgram.com/docs/kubernetes) for instructions on how to create these secrets.
 
 You may also override any default configuration values. See [the Values section](#values) for a list of available options, and the [samples directory](./samples) for examples of a standard installation.
 
@@ -271,7 +271,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | global.additionalLabels | object | `{}` | Additional labels to add to all Deepgram resources |
 | global.deepgramSecretRef | string | `nil` | Name of the pre-configured K8s Secret containing your Deepgram self-hosted API key. See chart docs for more details. |
 | global.outstandingRequestGracePeriod | int | `1800` | When an API or Engine container is signaled to shutdown via Kubernetes sending a SIGTERM signal, the container will stop listening on its port, and no new requests will be routed to that container. However, the container will continue to run until all existing batch or streaming requests have completed, after which it will gracefully shut down.  Batch requests should be finished within 10-15 minutes, but streaming requests can proceed indefinitely.  outstandingRequestGracePeriod defines the period (in sec) after which Kubernetes will forcefully shutdown the container, terminating any outstanding connections. 1800 / 60 sec/min = 30 mins |
-| global.pullSecretRef | string | `nil` | Name of the pre-configured K8s Secret with image repository credentials. See chart docs for more details. |
+| global.pullSecretRef | string | `nil` | If using images from the Deepgram Quay image repositories, or another private registry to which your cluster doesn't have default access, you will need to provide a pre-configured K8s Secret with image repository credentials. See chart docs for more details. |
 | gpu-operator | object | `{"driver":{"enabled":true,"version":"550.54.15"},"enabled":true,"toolkit":{"enabled":true,"version":"v1.15.0-ubi8"}}` | Passthrough values for [NVIDIA GPU Operator Helm chart](https://github.com/NVIDIA/gpu-operator/blob/master/deployments/gpu-operator/values.yaml) You may use the NVIDIA GPU Operator to manage installation of NVIDIA drivers and the container toolkit on nodes with attached GPUs. |
 | gpu-operator.driver.enabled | bool | `true` | Whether to install NVIDIA drivers on nodes where a NVIDIA GPU is detected. If your Kubernetes nodes run a base image that comes with NVIDIA drivers pre-configured, disable this option, but keep the parent `gpu-operator` and sibling `toolkit` options enabled. |
 | gpu-operator.driver.version | string | `"550.54.15"` | NVIDIA driver version to install. |

--- a/charts/deepgram-self-hosted/README.md.gotmpl
+++ b/charts/deepgram-self-hosted/README.md.gotmpl
@@ -26,7 +26,7 @@ helm repo update
 
 The Deepgram self-hosted chart requires Helm 3.7+ in order to install successfully. Please check your helm release before installation.
 
-You will need to provide your [self-service Deepgram licensing and credentials](https://developers.deepgram.com/docs/on-prem-self-service-tutorial) information. See `global.deepgramSecretRef` and `global.pullSecretRef` in the [Values section](#values) for more details.
+You will need to provide your [self-service Deepgram licensing and credentials](https://developers.deepgram.com/docs/on-prem-self-service-tutorial) information. See `global.deepgramSecretRef` and `global.pullSecretRef` in the [Values section](#values) for more details, and the [Deepgram Self-Hosted Kubernetes Guides](https://developers.deepgram.com/docs/kubernetes) for instructions on how to create these secrets.
 
 You may also override any default configuration values. See [the Values section](#values) for a list of available options, and the [samples directory](./samples) for examples of a standard installation.
 

--- a/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
@@ -26,8 +26,10 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/api/api.config.yaml") . | sha256sum }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.global.outstandingRequestGracePeriod }}
+      {{- if .Values.global.pullSecretRef }}
       imagePullSecrets:
-      - name: {{ required "Missing image repository credentials - see `global.pullSecretRef`" .Values.global.pullSecretRef }}
+      - name: {{ .Values.global.pullSecretRef }}
+      {{- end }}
       affinity:
         {{- toYaml .Values.api.affinity | nindent 8 }}
       tolerations:

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -26,8 +26,10 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/engine/engine.config.yaml") . | sha256sum }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.global.outstandingRequestGracePeriod }}
+      {{- if .Values.global.pullSecretRef }}
       imagePullSecrets:
-      - name: {{ required "Missing image repository credentials - see `global.pullSecretRef`" .Values.global.pullSecretRef }}
+      - name: {{ .Values.global.pullSecretRef }}
+      {{- end }}
       affinity:
         {{- toYaml .Values.engine.affinity | nindent 8 }}
       tolerations:

--- a/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
@@ -26,8 +26,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/license-proxy/license-proxy.config.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.global.pullSecretRef }}
       imagePullSecrets:
-      - name: {{ required "Missing image repository credentials - see `global.pullSecretRef`" .Values.global.pullSecretRef }}
+      - name: {{ .Values.global.pullSecretRef }}
+      {{- end }}
       affinity:
         {{- toYaml .Values.licenseProxy.affinity | nindent 8 }}
       tolerations:

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -1,5 +1,7 @@
 global:
-  # -- (string) Name of the pre-configured K8s Secret
+  # -- (string) If using images from the Deepgram Quay image repositories,
+  # or another private registry to which your cluster doesn't have default access,
+  # you will need to provide a pre-configured K8s Secret
   # with image repository credentials. See chart docs for more details.
   pullSecretRef:
 


### PR DESCRIPTION
There are cases where the Helm chart may not require credentials to access the Deepgram container image repositories hosted on Quay. This PR removes the firm requirement to include these credentials as a pull secret for pulling container images.

For example, a client may pull the images from Quay manually and push them into a private company repository that meets certain security or scanning requirements. Credentials to that private repo may be pre-configured in the cluster, so the pull secret shouldn't be mandatory. 

Another case is if a [Docker proxy](https://docs.docker.com/network/proxy/) is being used and credentials are supplied in the proxy. Then the credentials don't need to be exposed directly in the cluster with this Helm chart.

Resolves #14.