### PR TITLE
CI and PR template improvements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Proposed changes
+<!--
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+-->
+
+## Types of changes
+
+What types of changes does your code introduce to the Deepgram self-hosted resources?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update or tests (if none of the other choices apply)
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+
+- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
+- [ ] I have tested my changes in my local self-hosted environment
+  - Please describe your testing setup and methodology here
+- [ ] I have added necessary documentation (if appropriate)
+
+## Further comments
+
+<!--
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,25 @@ jobs:
             echo "README.md is out of date. Please run helm-docs and commit the changes."
             exit 1
           fi
+
+      - name: Check that chart version is bumped if chart appVersion is bumped
+        run: |
+          CHART_DIR="charts/deepgram-self-hosted"
+          if [ ! -f "$CHART_DIR/Chart.yaml" ]; then
+            echo "Error: Chart.yaml not found in $CHART_DIR"
+            exit 1
+          fi
+
+          OLD_VERSION=$(git show $GITHUB_BASE_REF:$CHART_DIR/Chart.yaml | grep '^version:' | awk '{print $2}')
+          NEW_VERSION=$(grep '^version:' $CHART_DIR/Chart.yaml | awk '{print $2}')
+          OLD_APP_VERSION=$(git show $GITHUB_BASE_REF:$CHART_DIR/Chart.yaml | grep '^appVersion:' | awk '{print $2}')
+          NEW_APP_VERSION=$(grep '^appVersion:' $CHART_DIR/Chart.yaml | awk '{print $2}')
+
+          if [[ "$OLD_VERSION" = "$NEW_VERSION" ]] && [[ "$OLD_APP_VERSION" != "$NEW_APP_VERSION" ]]; then
+            echo "Error: In $CHART_DIR/Chart.yaml, appVersion has been changed but version has not been bumped"
+            echo "Old appVersion: $OLD_APP_VERSION"
+            echo "New appVersion: $NEW_APP_VERSION"
+            echo "Chart version: $NEW_VERSION"
+            echo "Chart version should be bumped anytime the application version is bumped."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,18 @@ jobs:
             echo "Chart version should be bumped anytime the application version is bumped."
             exit 1
           fi
+
+      - name: Check that the chart changelog has been updated if the chart has changes
+        run: |
+          CHART_DIR="charts/deepgram-self-hosted"
+
+          echo "Non-documentation files changed in chart directory:"
+          # If there are changes to the chart directory besides the changelog file or documentation...
+          if git diff --name-only "$GITHUB_BASE_REF"... $CHART_DIR | grep -vE "^$CHART_DIR/(CHANGELOG\.md|README\.md(\..*)?)"; then
+          # ...make sure the changelog file is updated as well
+            if ! git diff --name-only "$GITHUB_BASE_REF"... "$CHART_DIR/CHANGELOG.md" | grep -q "$CHART_DIR/CHANGELOG.md"; then
+              echo "Detected changes to non-documentation files the helm chart directory, but the chart CHANGELOG.md was not updated."
+              echo "Please add a short desription of changes to the changelog under the \"Unreleased\" header."
+              exit 1
+            fi
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,18 +17,56 @@ jobs:
           fetch-depth: 0
           token: "${{ secrets.GH_SELFHOSTEDRESOURCES_RW }}"
 
+      # `chart-releaser-action` only performs a `git diff` on Chart files. If we have a workflow where we want to
+      # merge something without bumping the Chart version yet to create a release, the chart-releaser-action will
+      # fail, since git detects that changes have been made, but the Chart version wasn't bumped. We don't want an
+      # erroneous failure in this case, as that dev workflow is intentional. So this step detects if the Helm chart
+      # version was bumped, and only continues if it was.
+      #
+      # This relies on PRs being squashed when merged (as it compares the head commit to its parent).
+      # This is currently enforced in the repositories PR settings.
+      - name: Check if Chart version was bumped
+        id: check-chart-version
+        run: |
+          CHART_DIR="charts/deepgram-self-hosted"
+          if git diff --name-only HEAD^..HEAD | grep "^$CHART_DIR"; then
+            if [ ! -f "$CHART_DIR/Chart.yaml" ]; then
+              echo "Error: Chart.yaml not found in $CHART_DIR"
+              EXIT_CODE=1
+              continue
+            fi
+
+            OLD_VERSION=$(git show HEAD^:$CHART_DIR/Chart.yaml | grep '^version:' | awk '{print $2}')
+            NEW_VERSION=$(grep '^version:' $CHART_DIR/Chart.yaml | awk '{print $2}')
+
+            if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
+              echo "$CHART_DIR has been changed, but version has not been bumped, so not performing release."
+              echo "IS_CHART_VERSION_BUMPED=false" >> $GITHUB_OUTPUT
+            else
+              echo "$CHART_DIR has been updated, and version has been bumped from $OLD_VERSION to $NEW_VERSION."
+              echo "Proceeding with release..."
+              echo "IS_CHART_VERSION_BUMPED=true" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "deepgram-self-hosted chart was not modified."
+            echo "IS_CHART_VERSION_BUMPED=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Configure Git
+        if: steps.check-chart-version.outputs.IS_CHART_VERSION_BUMPED == 'true'
         run: |
           # Give CI a git identity for its commit message
           git config --global user.email "robot@deepgram.com"
           git config --global user.name "Deepgram CI"
 
       - name: Install Helm
+        if: steps.check-chart-version.outputs.IS_CHART_VERSION_BUMPED == 'true'
         uses: azure/setup-helm@v4
         env:
           GITHUB_TOKEN: "${{ secrets.GH_SELFHOSTEDRESOURCES_RW }}"
 
       - name: Add Helm chart repositories for chart dependencies
+        if: steps.check-chart-version.outputs.IS_CHART_VERSION_BUMPED == 'true'
         run: |
           helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
@@ -36,6 +74,7 @@ jobs:
           helm repo update
 
       - name: Run chart-releaser
+        if: steps.check-chart-version.outputs.IS_CHART_VERSION_BUMPED == 'true'
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GH_SELFHOSTEDRESOURCES_RW }}"

--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
 - Resolves a mismatch between PVC and SC prefix naming convention.
+
+### Changed
+
+- Make `imagePullSecrets` optional.
 
 ## [0.2.2-beta] - 2024-06-27
 
@@ -52,7 +56,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Initial implementation of the Helm chart.
 
 
+[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.2.2-beta...HEAD
+[0.2.2-beta]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.2.1-beta...deepgram-self-hosted-0.2.2-beta
 [0.2.1-beta]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.2.0-beta...deepgram-self-hosted-0.2.1-beta
 [0.2.0-beta]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.1.1-alpha...deepgram-self-hosted-0.2.0-beta
 [0.1.1-alpha]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.1.0-alpha...deepgram-self-hosted-0.1.1-alpha
 [0.1.0-alpha]: https://github.com/deepgram/self-hosted-resources/releases/tag/deepgram-self-hosted-0.1.0-alpha
+
+


### PR DESCRIPTION
## Proposed changes

This change improves the DevOps portion of this repo in the following ways:

- Adds a standardized Pull Request template
- Adds a CI check to ensure that the Helm chart appVersion is not updated without also bumping the chart Version
- Adds a CI check to ensure that the chart changelog is updated if the chart is updated
- Improves reliability of the publish GH action
  - The `chart-releaser-action` will attempt to run if git detects any changes at all in the chart directory. 
  - This means if a change was merged, but we aren't yet cutting a release by bumping the version number, git will still detect changes and so `chart-releaser-action` will attempt to run.
  - It will create a tarball and attempt to create a release, but under the same version as the current/latest version. GitHub will return an error complaining that a release already exists under that name/version:
   ```
   Error: error creating GitHub release deepgram-self-hosted-0.2.2-beta: POST https://api.github.com/repos/deepgram/self-hosted-resources/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
  ```
  - So instead, this PR adds an explicit check to see if the Chart version has been bumped before taking the GH action

## Types of changes

What types of changes does your code introduce to the Deepgram self-hosted resources?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
  - I tested all GH action modifications locally using [act](https://github.com/nektos/act).
- [x] I have added necessary documentation (if appropriate)