### PR TITLE
[ISSUE-27] Fix EFS Storage Class Mismatch with Name Prefix

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Resolves a mismatch between PVC and SC prefix naming convention.
+
 ## [0.2.2-beta] - 2024-06-27
 
 ### Added

--- a/charts/deepgram-self-hosted/templates/volumes/aws/efs.pvc.yaml
+++ b/charts/deepgram-self-hosted/templates/volumes/aws/efs.pvc.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: aws-efs-sc
+  storageClassName: {{ .Values.engine.modelManager.volumes.aws.efs.namePrefix }}-aws-efs-sc
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
This change fixes a template issue when using AWS EFS as the storage for self-hosted deployments