### PR TITLE
Fix malformed `or` statement with serviceAccounts

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Resolves a mismatch between PVC and SC prefix naming convention.
+- Resolves error when specifying custom service account names.
 
 ## [0.2.2-beta] - 2024-06-27
 

--- a/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml .Values.api.tolerations | nindent 8 }}
       securityContext:
         {{- toYaml .Values.licenseProxy.securityContext | nindent 8 }}
-      {{- if or .Values.api.serviceAccount.create or .Values.api.serviceAccount.name }}
+      {{- if or .Values.api.serviceAccount.create .Values.api.serviceAccount.name }}
       serviceAccountName: {{ default (printf "%s-sa" .Values.api.namePrefix) .Values.api.serviceAccount.name }}
       {{- end }}
       containers:

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml .Values.engine.tolerations | nindent 8 }}
       securityContext:
         {{- toYaml .Values.licenseProxy.securityContext | nindent 8 }}
-      {{- if or .Values.engine.serviceAccount.create or .Values.engine.serviceAccount.name }}
+      {{- if or .Values.engine.serviceAccount.create .Values.engine.serviceAccount.name }}
       serviceAccountName: {{ default (printf "%s-sa" .Values.engine.namePrefix) .Values.engine.serviceAccount.name }}
       {{- end }}
       containers:

--- a/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml .Values.licenseProxy.tolerations | nindent 8 }}
       securityContext:
         {{- toYaml .Values.licenseProxy.securityContext | nindent 8 }}
-      {{- if or .Values.licenseProxy.serviceAccount.create or .Values.licenseProxy.serviceAccount.name }}
+      {{- if or .Values.licenseProxy.serviceAccount.create .Values.licenseProxy.serviceAccount.name }}
       serviceAccountName: {{ default (printf "%s-sa" .Values.licenseProxy.namePrefix) .Values.licenseProxy.serviceAccount.name }}
       {{- end }}
       containers:


### PR DESCRIPTION
## Proposed changes

This PR removes a dangling `or` directive in between another `or` statement that caused an error when `serviceAccount.create` was set to false and the outer `or` statement continued to try and evaluate the next condition.

Fixes #25 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
  - Verified behavior locally with `helm template`. Was able to reproduce error from #25 before fix, and error is resolved after the fix.
- [x] I have added necessary documentation (if appropriate)