### PR TITLE
Add explicit remote when using $GITHUB_BASE_REF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,9 @@ jobs:
             exit 1
           fi
 
-          OLD_VERSION=$(git show $GITHUB_BASE_REF:$CHART_DIR/Chart.yaml | grep '^version:' | awk '{print $2}')
+          OLD_VERSION=$(git show origin/$GITHUB_BASE_REF:$CHART_DIR/Chart.yaml | grep '^version:' | awk '{print $2}')
           NEW_VERSION=$(grep '^version:' $CHART_DIR/Chart.yaml | awk '{print $2}')
-          OLD_APP_VERSION=$(git show $GITHUB_BASE_REF:$CHART_DIR/Chart.yaml | grep '^appVersion:' | awk '{print $2}')
+          OLD_APP_VERSION=$(git show origin/$GITHUB_BASE_REF:$CHART_DIR/Chart.yaml | grep '^appVersion:' | awk '{print $2}')
           NEW_APP_VERSION=$(grep '^appVersion:' $CHART_DIR/Chart.yaml | awk '{print $2}')
 
           if [[ "$OLD_VERSION" = "$NEW_VERSION" ]] && [[ "$OLD_APP_VERSION" != "$NEW_APP_VERSION" ]]; then
@@ -67,9 +67,9 @@ jobs:
 
           echo "Non-documentation files changed in chart directory:"
           # If there are changes to the chart directory besides the changelog file or documentation...
-          if git diff --name-only "$GITHUB_BASE_REF"... $CHART_DIR | grep -vE "^$CHART_DIR/(CHANGELOG\.md|README\.md(\..*)?)"; then
+          if git diff --name-only origin/"$GITHUB_BASE_REF"... $CHART_DIR | grep -vE "^$CHART_DIR/(CHANGELOG\.md|README\.md(\..*)?)"; then
           # ...make sure the changelog file is updated as well
-            if ! git diff --name-only "$GITHUB_BASE_REF"... "$CHART_DIR/CHANGELOG.md" | grep -q "$CHART_DIR/CHANGELOG.md"; then
+            if ! git diff --name-only origin/"$GITHUB_BASE_REF"... "$CHART_DIR/CHANGELOG.md" | grep -q "$CHART_DIR/CHANGELOG.md"; then
               echo "Detected changes to non-documentation files the helm chart directory, but the chart CHANGELOG.md was not updated."
               echo "Please add a short desription of changes to the changelog under the \"Unreleased\" header."
               exit 1


### PR DESCRIPTION
## Proposed changes

When submitting #29, I noticed the [CI action succeeded but had errors](https://github.com/deepgram/self-hosted-resources/actions/runs/9941681484/job/27461328089#step:9:23). These errors didn't occur locally when running with `act`. After digging into it, I found [this issue](https://github.com/actions/checkout/issues/296) with the `checkout` GitHub action that seems to suggest we need to explicitly define the remote for $GITHUB_BASE_REF for it to work. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have tested my changes in my local self-hosted environment
  - As this action is specific to remote GH actions and I can't reproduce locally, I'm not sure how to test locally
- [x] I have added necessary documentation (if appropriate)
