### PR TITLE
remove compose file versions

### DIFF
--- a/docker/docker-compose.license-proxy.yml
+++ b/docker/docker-compose.license-proxy.yml
@@ -1,7 +1,5 @@
 # Make sure to replace placeholder paths to config files and model directories
 
-version: "3.7"
-
 services:
   # The speech API service.
   api:

--- a/docker/docker-compose.standard.yml
+++ b/docker/docker-compose.standard.yml
@@ -1,7 +1,5 @@
 # Make sure to replace placeholder paths to config files and model directories
 
-version: "3.7"
-
 services:
   # The speech API service.
   api:

--- a/podman/podman-compose.license-proxy.yml
+++ b/podman/podman-compose.license-proxy.yml
@@ -1,7 +1,5 @@
 # Make sure to replace placeholder paths to config files and model directories
 
-version: "3.7"
-
 services:
   # The speech API service.
   api:

--- a/podman/podman-compose.standard.yml
+++ b/podman/podman-compose.standard.yml
@@ -1,7 +1,5 @@
 # Make sure to replace placeholder paths to config files and model directories
 
-version: "3.7"
-
 services:
   # The speech API service.
   api:


### PR DESCRIPTION
## Proposed changes

Remove Compose file version keys, as they are [now deprecated](https://github.com/compose-spec/compose-spec/blob/main/04-version-and-name.md) and emit a warning when used.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
- [x] I have added necessary documentation (if appropriate)

