### PR TITLE
Fix onprem sample file comment

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a misleading comment in the `03-basic-setup-onprem.yaml` sample file that wrongly suggested `engine.modelManager.volumes.customVolumeClaim.name` should be a `PersistentVolume` instead of a `PersistentVolumeClaim`
+
 ## [0.4.0] - 2024-07-25
 
 ### Added

--- a/charts/deepgram-self-hosted/samples/03-basic-setup-onprem.yaml
+++ b/charts/deepgram-self-hosted/samples/03-basic-setup-onprem.yaml
@@ -40,7 +40,7 @@ engine:
     volumes:
       customVolumeClaim:
         enabled: true
-        name: deepgram-models-pv # Replace with the name of the local PersistentVolume you have created
+        name: deepgram-models-pvc # Replace with the name of a PersistentVolumeClaim that maps to the PersistentVolume you have created
         modelsDirectory: "/"
 
 licenseProxy:


### PR DESCRIPTION
## Proposed changes

The onprem sample file has a typo that wrongly suggests the `engine.modelManager.volumes.customVolumeClaim.name` should be a `PersistentVolume` instead of a `PersistentVolumeClaim`. This PR addresses that.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [-] I have tested my changes in my local self-hosted environment
- [x] I have added necessary documentation (if appropriate)

