### PR TITLE
Fix sample k8s secret command for quay credentials

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Update sample files to fix an issue with sample command for Kubernetes Secret creation storing Quay credential
+  - Previous command used `--from-file` with the user's Docker configuration file. Some local secret managers, like
+    Apple Keychain, scrub this file for sensitive information, which would result in an empty secret being created.
+
 ## [0.5.0] - 2024-08-27
 
 ### Added

--- a/charts/deepgram-self-hosted/samples/01-basic-setup-aws.values.yaml
+++ b/charts/deepgram-self-hosted/samples/01-basic-setup-aws.values.yaml
@@ -10,9 +10,10 @@ global:
   # with the following commands:
   # ```bash
   # docker login quay.io
-  # kubectl create secret generic dg-regcred \
-  #   --from-file=.dockerconfigjson=$HOME/.docker/config.json \
-  #   --type=kubernetes.io/dockerconfigjson
+  # kubectl create secret docker-registry dg-regcred \
+  #   --docker-server=quay.io \
+  #   --docker-username='QUAY_DG_USER' \
+  #   --docker-password='QUAY_DG_PASSWORD'
   # ```
   pullSecretRef: "dg-regcred"
 

--- a/charts/deepgram-self-hosted/samples/02-basic-setup-gcp.yaml
+++ b/charts/deepgram-self-hosted/samples/02-basic-setup-gcp.yaml
@@ -10,9 +10,10 @@ global:
   # with the following commands:
   # ```bash
   # docker login quay.io
-  # kubectl create secret generic dg-regcred \
-  #   --from-file=.dockerconfigjson=$HOME/.docker/config.json \
-  #   --type=kubernetes.io/dockerconfigjson
+  # kubectl create secret docker-registry dg-regcred \
+  #   --docker-server=quay.io \
+  #   --docker-username='QUAY_DG_USER' \
+  #   --docker-password='QUAY_DG_PASSWORD'
   # ```
   pullSecretRef: "dg-regcred"
 

--- a/charts/deepgram-self-hosted/samples/03-basic-setup-onprem.yaml
+++ b/charts/deepgram-self-hosted/samples/03-basic-setup-onprem.yaml
@@ -10,9 +10,10 @@ global:
   # with the following commands:
   # ```bash
   # docker login quay.io
-  # kubectl create secret generic dg-regcred \
-  #   --from-file=.dockerconfigjson=$HOME/.docker/config.json \
-  #   --type=kubernetes.io/dockerconfigjson
+  # kubectl create secret docker-registry dg-regcred \
+  #   --docker-server=quay.io \
+  #   --docker-username='QUAY_DG_USER' \
+  #   --docker-password='QUAY_DG_PASSWORD'
   # ```
   pullSecretRef: "dg-regcred"
 


### PR DESCRIPTION
## Proposed changes

Update sample files to fix an issue with sample files. The sample command for creating a Kubernetes Secret to store Quay credentials would fail in certain situations, most commonly on MacOS with Docker Desktop installed.

Previous command:
```
kubectl create secret generic dg-regcred \
  --from-file=.dockerconfigjson=$HOME/.docker/config.json \
  --type=kubernetes.io/dockerconfigjson
```

This previous command used `--from-file` with the user's Docker configuration file. When using MacOS with Docker Desktop installed, Docker Desktop will store credentials in Apple Keychain, leaving the configuration file empty. The k8s secret creation then results in an empty secret being created, as it doesn't attempt to pull the secret from Apple Keychain.

This PR changes the default command to work regardless of whether the config file is scrubbed, by directly passing the credentials.

> [!NOTE]
> Deepgram provides this sample command for convenience, however, we still recommend using an external Secrets store provider to manage Kubernetes secrets [see docs](https://developers.deepgram.com/docs/securing-your-cluster#secrets). 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
- [x] I have added necessary documentation (if appropriate)

