### PR TITLE
Use AWS accelerated AMIs

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- AWS samples updated to take advantage of new [EKS accelerated AMIs](https://github.com/awslabs/amazon-eks-ami/releases/tag/v20240928), which bundle the required NVIDIA driver and toolkit instead of being installed by the NVIDIA GPU operator 
+
 ## [0.6.0] - 2024-09-27
 
 ### Added

--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- AWS samples updated to take advantage of new [EKS accelerated AMIs](https://github.com/awslabs/amazon-eks-ami/releases/tag/v20240928), which bundle the required NVIDIA driver and toolkit instead of being installed by the NVIDIA GPU operator 
+- AWS samples updated to take advantage of new [EKS accelerated AMIs](https://aws.amazon.com/about-aws/whats-new/2024/10/amazon-eks-nvidia-aws-neuron-instance-types-al2023/), which bundle the required NVIDIA driver and toolkit instead of being installed by the NVIDIA GPU operator 
 
 ## [0.6.0] - 2024-09-27
 

--- a/charts/deepgram-self-hosted/samples/01-basic-setup-aws.cluster-config.yaml
+++ b/charts/deepgram-self-hosted/samples/01-basic-setup-aws.cluster-config.yaml
@@ -40,7 +40,7 @@ managedNodeGroups:
     desiredCapacity: 0
     maxSize: 8
     instanceType: g6.2xlarge
-    amiFamily: Ubuntu2204
+    amiFamily: AmazonLinux2023
     labels:
       k8s.deepgram.com/node-type: engine
       k8s.amazonaws.com/accelerator: nvidia-l4
@@ -58,7 +58,7 @@ managedNodeGroups:
     desiredCapacity: 0
     maxSize: 2
     instanceType: c5n.xlarge
-    amiFamily: Ubuntu2204
+    amiFamily: AmazonLinux2023
     labels:
       k8s.deepgram.com/node-type: api
     iam:
@@ -70,7 +70,7 @@ managedNodeGroups:
     desiredCapacity: 0
     maxSize: 2
     instanceType: t3.large
-    amiFamily: Ubuntu2204
+    amiFamily: AmazonLinux2023
     labels:
       k8s.deepgram.com/node-type: license-proxy
     iam:

--- a/charts/deepgram-self-hosted/samples/01-basic-setup-aws.values.yaml
+++ b/charts/deepgram-self-hosted/samples/01-basic-setup-aws.values.yaml
@@ -140,3 +140,15 @@ cluster-autoscaler:
   autoDiscovery:
     clusterName: "deepgram-self-hosted-cluster"
   awsRegion: "us-west-2"
+
+gpu-operator:
+  enabled: true
+
+  # If using EKS accelerated AMIs based on Amazon Linux 2023 (default with Deepgram guides as of Oct 2024),
+  # driver and toolkit come bundled with the AMI.
+  #
+  # If using other AMIs, such as Ubuntu, you should re-enable the driver and toolkit below.
+  driver:
+    enabled: false
+  toolkit:
+    enabled: false


### PR DESCRIPTION
## Proposed changes

Previously, Amazon did not offer any official AMIs that included a recent version of the NVIDIA driver/toolkit and updated versions of system packages. The community demand for this has grown such that two weeks ago AWS released [an EKS accelerated AMI] based on Amazon Linux 2023. This means we now have an officially supported AWS AMI with bundled drivers and toolkits that is compatible with Deepgram workloads.

This PR updates the sample directory to use these new AMIs, and adjust the AWS example `values.yaml` file to no longer manually install NVIDIA drivers with the GPU operator Helm Chart. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
  - I created a cluster using `eksctl v0.192.0` and deployed the Helm chart and verified the Engine container had access to the GPU.
- [x] I have added necessary documentation (if appropriate)
