### PR TITLE
Add tolerations for model download job

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Add the Engine Deployment tolerations to the Engine's model download Job.
+
 ## [0.7.0] - 2024-10-24
 
 ### Added

--- a/charts/deepgram-self-hosted/templates/volumes/aws/efs-model-download.job.yaml
+++ b/charts/deepgram-self-hosted/templates/volumes/aws/efs-model-download.job.yaml
@@ -14,6 +14,8 @@ spec:
     spec:
       affinity:
         {{- toYaml .Values.engine.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.engine.tolerations | nindent 8 }}
       containers:
       - name: model-management
         image: alpine


### PR DESCRIPTION
## Proposed changes

The AWS model download job is coupled with the Engine deployment as currently implemented, and uses the same affinity. This fixes a scheduling issue by also adding the Engine tolerations block to that model download job, to avoid being blocked by node taints.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist


- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
- [x] I have added necessary documentation (if appropriate)

## Further comments

Resolves #48 
