### PR TITLE
Remove resource limits on Compose file templates

### DIFF
--- a/docker/docker-compose.license-proxy.yml
+++ b/docker/docker-compose.license-proxy.yml
@@ -28,15 +28,6 @@ services:
     # Invoke the API server
     command: -v serve /api.toml
 
-    # Default resource limits. Increase as needed.
-    # For more details, see:
-    #     https://developers.deepgram.com/docs/self-hosted-deployment-environments#hardware-specifications
-    deploy:
-      resources:
-        limits:
-          cpus: "1.80"
-          memory: 3800M
-
     # Make sure the License Proxy is available for licensing
     depends_on:
       - license-proxy
@@ -64,19 +55,6 @@ services:
     # Invoke the Engine service
     command: -v serve /engine.toml
 
-    # Default resource limits. Increase as needed.
-    # For more details, see:
-    #     https://developers.deepgram.com/docs/self-hosted-deployment-environments#hardware-specifications
-    deploy:
-      resources:
-        limits:
-          cpus: "3.80"
-          memory: 30G
-        reservations:
-          devices:
-            - capabilities: ["gpu"]
-              count: 1
-
     # Make sure the License Proxy is available for licensing
     depends_on:
       - license-proxy
@@ -101,12 +79,3 @@ services:
 
     # Invoke the License Proxy service
     command: -v serve /license-proxy.toml
-
-    # Default resource limits. Increase as needed.
-    # For more details, see:
-    #     https://developers.deepgram.com/docs/self-hosted-deployment-environments#hardware-specifications
-    deploy:
-      resources:
-        limits:
-          cpus: "1.00"
-          memory: 1G

--- a/docker/docker-compose.standard.yml
+++ b/docker/docker-compose.standard.yml
@@ -28,15 +28,6 @@ services:
     # Invoke the API server
     command: -v serve /api.toml
 
-    # Default resource limits. Increase as needed.
-    # For more details, see:
-    #     https://developers.deepgram.com/docs/self-hosted-deployment-environments#hardware-specifications
-    deploy:
-      resources:
-        limits:
-          cpus: "1.80"
-          memory: 3800M
-
   # The speech engine service.
   engine:
     image: quay.io/deepgram/self-hosted-engine:release-241121
@@ -59,16 +50,3 @@ services:
 
     # Invoke the Engine service
     command: -v serve /engine.toml
-
-    # Default resource limits. Increase as needed.
-    # For more details, see:
-    #     https://developers.deepgram.com/docs/self-hosted-deployment-environments#hardware-specifications
-    deploy:
-      resources:
-        limits:
-          cpus: "3.80"
-          memory: 30G
-        reservations:
-          devices:
-            - capabilities: ["gpu"]
-              count: 1

--- a/podman/podman-compose.license-proxy.yml
+++ b/podman/podman-compose.license-proxy.yml
@@ -25,15 +25,6 @@ services:
     # Invoke the API server
     command: -v serve /api.toml
 
-    # Default resource limits. Increase as needed.
-    # For more details, see:
-    #     https://developers.deepgram.com/docs/self-hosted-deployment-environments#hardware-specifications
-    deploy:
-      resources:
-        limits:
-          cpus: "1.80"
-          memory: 3800M
-
     # Make sure the License Proxy is available for licensing
     depends_on:
       - license-proxy
@@ -65,19 +56,6 @@ services:
     # Invoke the Engine service
     command: -v serve /engine.toml
 
-    # Default resource limits. Increase as needed.
-    # For more details, see:
-    #     https://developers.deepgram.com/docs/self-hosted-deployment-environments#hardware-specifications
-    deploy:
-      resources:
-        limits:
-          cpus: "3.80"
-          memory: 30G
-        reservations:
-          devices:
-            - capabilities: ["gpu"]
-              count: 1
-
     # Make sure the License Proxy is available for licensing
     depends_on:
       - license-proxy
@@ -105,12 +83,3 @@ services:
 
     # Invoke the License Proxy service
     command: -v serve /license-proxy.toml
-
-    # Default resource limits. Increase as needed.
-    # For more details, see:
-    #     https://developers.deepgram.com/docs/self-hosted-deployment-environments#hardware-specifications
-    deploy:
-      resources:
-        limits:
-          cpus: "1.00"
-          memory: 1G

--- a/podman/podman-compose.standard.yml
+++ b/podman/podman-compose.standard.yml
@@ -25,15 +25,6 @@ services:
     # Invoke the API server
     command: -v serve /api.toml
 
-    # Default resource limits. Increase as needed.
-    # For more details, see:
-    #     https://developers.deepgram.com/docs/self-hosted-deployment-environments#hardware-specifications
-    deploy:
-      resources:
-        limits:
-          cpus: "1.80"
-          memory: 3800M
-
   # The speech engine service.
   engine:
     image: quay.io/deepgram/self-hosted-engine:release-241121
@@ -60,16 +51,3 @@ services:
 
     # Invoke the Engine service
     command: -v serve /engine.toml
-
-    # Default resource limits. Increase as needed.
-    # For more details, see:
-    #     https://developers.deepgram.com/docs/self-hosted-deployment-environments#hardware-specifications
-    deploy:
-      resources:
-        limits:
-          cpus: "3.80"
-          memory: 30G
-        reservations:
-          devices:
-            - capabilities: ["gpu"]
-              count: 1


### PR DESCRIPTION
## Proposed changes

Resource limits can be an effective way to prevent containers from starving eachother. 

However, in a single VM running multiple Deepgram containers (most common use case with Docker), allowing containers to have more ebb and flow in their resource usage can lead to greater performance and easier management. 

This also prevents artificially low limits being enforced when these templates are used for more powerful instance types, but users forget to increase the default limits.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)
  - Updated best practice on Compose templates 

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
- [x] I have added necessary documentation (if appropriate)
