### PR TITLE
Fix Helm Chart Prometheus Adapter Metrics

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Fixed default ratio metrics in Prometheus Adapter chart values to use 0.0 to 1.0 scale to match autoscaling documentation
+
 ## [0.8.0] - 2024-11-21
 
 ### Added

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -766,7 +766,7 @@ prometheus-adapter:
       - name:
           as: "engine_estimated_stream_capacity"
         seriesQuery: 'engine_active_requests{kind="stream"}'
-        metricsQuery: 'avg_over_time((sum(engine_active_requests{kind="stream"}) / sum(engine_estimated_stream_capacity) * 100)[1m:1m])'
+        metricsQuery: 'avg_over_time((sum(engine_active_requests{kind="stream"}) / sum(engine_estimated_stream_capacity))[1m:1m])'
         resources:
           overrides:
             namespace: { resource: "namespace" }
@@ -775,7 +775,7 @@ prometheus-adapter:
       - name:
           as: "engine_requests_active_to_max_ratio"
         seriesQuery: "engine_max_active_requests"
-        metricsQuery: "avg_over_time((sum(engine_active_requests) / sum(engine_max_active_requests) * 100)[1m:1m])"
+        metricsQuery: "avg_over_time((sum(engine_active_requests) / sum(engine_max_active_requests))[1m:1m])"
         resources:
           overrides:
             namespace: { resource: "namespace" }


### PR DESCRIPTION
## Proposed changes
The x100 multiplier in the existing metrics is not compatible with the scaling ratio from 0.0 to 1.0 in the chart.  I'm removing the multiplier to make it consistent with the comments in the values file for scaling.auto.engine.metrics.requestCapacityRatio

This could be a breaking change for any users that have changed the ratio to use a scale from 0 to 100 rather than changing the custom metrics.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes

What types of changes does your code introduce to the Deepgram self-hosted resources?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
  - Please describe your testing setup and methodology here
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
