### PR TITLE
Support/self hosted aura 2

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## [0.16.0] - 2025-07-31
+
+### Added
+
+- Updated default container tags to July 2025 release (`release-250731`). Refer to the [main Deepgram changelog](https://developers.deepgram.com/changelog#deepgram-self-hosted-july-2025-release-250731) for additional details.
+
 ## [0.15.0] - 2025-07-10
 
 ### Added
@@ -197,7 +203,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Initial implementation of the Helm chart.
 
 
-[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.14.0...HEAD
+[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.16.0...HEAD
+[0.16.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.15.0...0.16.0
+[0.15.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.14.0...0.15.0
 [0.14.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.13.0...0.14.0
 [0.13.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.12.0...0.13.0
 [0.12.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.11.1...0.12.0

--- a/charts/deepgram-self-hosted/Chart.yaml
+++ b/charts/deepgram-self-hosted/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: deepgram-self-hosted
 type: application
-version: 0.15.0
-appVersion: "release-250710"
+version: 0.16.0
+appVersion: "release-250731"
 description: A Helm chart for running Deepgram services in a self-hosted environment
 home: "https://developers.deepgram.com/docs/self-hosted-introduction"
 sources: ["https://github.com/deepgram/self-hosted-resources"]

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -1,6 +1,6 @@
 # deepgram-self-hosted
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-250710](https://img.shields.io/badge/AppVersion-release--250710-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-250731](https://img.shields.io/badge/AppVersion-release--250731-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
 
 A Helm chart for running Deepgram services in a self-hosted environment
 
@@ -193,7 +193,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | api.features.formatEntityTags | bool | `false` | Enables format entity tags on pre-recorded audio *if* a valid NER model is available. |
 | api.image.path | string | `"quay.io/deepgram/self-hosted-api"` | path configures the image path to use for creating API containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | api.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram API image |
-| api.image.tag | string | `"release-250710"` | tag defines which Deepgram release to use for API containers |
+| api.image.tag | string | `"release-250731"` | tag defines which Deepgram release to use for API containers |
 | api.livenessProbe | object | `` | Liveness probe customization for API pods. |
 | api.namePrefix | string | `"deepgram-api"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram API containers. |
 | api.readinessProbe | object | `` | Readiness probe customization for API pods. |
@@ -233,7 +233,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | engine.halfPrecision.state | string | `"auto"` | Engine will automatically enable half precision operations if your GPU supports them. You can explicitly enable or disable this behavior with the state parameter which supports `"enable"`, `"disabled"`, and `"auto"`. |
 | engine.image.path | string | `"quay.io/deepgram/self-hosted-engine"` | path configures the image path to use for creating Engine containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | engine.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram Engine image |
-| engine.image.tag | string | `"release-250710"` | tag defines which Deepgram release to use for Engine containers |
+| engine.image.tag | string | `"release-250731"` | tag defines which Deepgram release to use for Engine containers |
 | engine.livenessProbe | object | `` | Liveness probe customization for Engine pods. |
 | engine.metricsServer | object | `` | metricsServer exposes an endpoint on each Engine container for reporting inference-specific system metrics. See https://developers.deepgram.com/docs/metrics-guide#deepgram-engine for more details. |
 | engine.metricsServer.host | string | `"0.0.0.0"` | host is the IP address to listen on for metrics requests. You will want to listen on all interfaces to interact with other pods in the cluster. |
@@ -291,7 +291,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | licenseProxy.enabled | bool | `false` | The License Proxy is optional, but highly recommended to be deployed in production to enable highly available environments. |
 | licenseProxy.image.path | string | `"quay.io/deepgram/self-hosted-license-proxy"` | path configures the image path to use for creating License Proxy containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | licenseProxy.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram License Proxy image |
-| licenseProxy.image.tag | string | `"release-250710"` | tag defines which Deepgram release to use for License Proxy containers |
+| licenseProxy.image.tag | string | `"release-250731"` | tag defines which Deepgram release to use for License Proxy containers |
 | licenseProxy.keepUpstreamServerAsBackup | bool | `true` | Even with a License Proxy deployed, API and Engine pods can be configured to keep the upstream `license.deepgram.com` license server as a fallback licensing option if the License Proxy is unavailable. Disable this option if you are restricting API/Engine Pod network access for security reasons, and only the License Proxy should send egress traffic to the upstream license server. |
 | licenseProxy.livenessProbe | object | `` | Liveness probe customization for Proxy pods. |
 | licenseProxy.namePrefix | string | `"deepgram-license-proxy"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram License Proxy containers. |

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -112,7 +112,7 @@ api:
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram API image
     pullPolicy: IfNotPresent
     # -- tag defines which Deepgram release to use for API containers
-    tag: release-250710
+    tag: release-250731
 
   # -- Additional labels to add to API resources
   additionalLabels: {}
@@ -280,7 +280,7 @@ engine:
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram Engine image
     pullPolicy: IfNotPresent
     # -- tag defines which Deepgram release to use for Engine containers
-    tag: release-250710
+    tag: release-250731
 
   # -- Additional labels to add to Engine resources
   additionalLabels: {}
@@ -536,7 +536,7 @@ licenseProxy:
     # Deepgram images into a private container registry.
     path: quay.io/deepgram/self-hosted-license-proxy
     # -- tag defines which Deepgram release to use for License Proxy containers
-    tag: release-250710
+    tag: release-250731
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram
     # License Proxy image
     pullPolicy: IfNotPresent

--- a/common/license_proxy_deploy/api.aura-2-en.toml
+++ b/common/license_proxy_deploy/api.aura-2-en.toml
@@ -1,0 +1,123 @@
+### Keep in mind that all paths are in-container paths, and do not need to exist
+### on the host machine.
+
+
+### Configure license validation by passing in a DEEPGRAM_API_KEY environment variable
+### See https://developers.deepgram.com/docs/deploy-deepgram-services#credentials
+[license]
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+server_url = ["https://license-proxy:8443", "https://license.deepgram.com"]
+
+
+### Configure how the API will listen for your requests
+[server]
+### The base URL (prefix) for requests to the API.
+base_url = "/v1"
+### The IP address to listen on. Since this is likely running in a Docker
+### container, you will probably want to listen on all interfaces.
+host = "0.0.0.0"
+### The port to listen on
+port = 8080
+
+### How long to wait for a connection to a callback URL.
+callback_conn_timeout = "1s"
+### How long to wait for a response to a callback URL.
+callback_timeout = "10s"
+
+### How long to wait for a connection to a fetch URL.
+fetch_conn_timeout = "1s"
+### How long to wait for a response to a fetch URL.
+fetch_timeout = "60s"
+
+
+### By default, the API listens over HTTP. By passing both a certificate
+### and a key file, the API will instead listen over HTTPS.
+###
+### This performs TLS termination only, and does not provide any
+### additional authentication.
+[server.https]
+# cert_file = "/path/to/cert.pem"
+# key_file = "/path/to/key.pem"
+
+
+### Specify custom DNS resolution options.
+[resolver]
+### Specify custom domain name server(s).
+### Format is "{IP} {PORT} {PROTOCOL (tcp or udp)}"
+# nameservers = ["127.0.0.1 53 udp"]
+
+### If specifying a custom DNS nameserver, set the DNS TTL value.
+# max_ttl = 10
+
+
+### Limit the number of active requests handled by a single API container.
+### If additional requests beyond the limit are sent, API will return
+### a 429 HTTP status code. Default is no limit.
+[concurrency_limit]
+# active_requests =
+
+
+### Enable ancillary features
+[features]
+### Enables topic detection *if* a valid topic detection model is available
+topic_detection = true # or false
+
+### Enables summarization *if* a valid summarization model is available
+summarization = true # or false
+
+### Enables pre-recorded entity detection *if* a valid entity detection model is available
+entity_detection = false # or true
+
+### Enables pre-recorded entity-based redaction *if* a valid entity detection model is available
+entity_redaction = false # or true
+
+### Enables pre-recorded entity formatting *if* a valid NER model is available
+format_entity_tags = false # or true
+
+### If API is receiving requests faster than Engine can process them, a request
+### queue will form. By default, this queue is stored in memory. Under high load,
+### the queue may grow too large and cause Out-Of-Memory errors. To avoid this,
+### set a disk_buffer_path to buffer the overflow on the request queue to disk.
+###
+### WARN: This is only to temporarily buffer requests during high load.
+### If there is not enough Engine capacity to process the queued requests over time,
+### the queue (and response time) will grow indefinitely.
+# disk_buffer_path = "/path/to/disk/buffer/directory"
+
+### Enables streaming TTS *if* a valid Aura TTS model is available
+speak_streaming = true # or false
+
+### Configure the backend pool of speech engines (generically referred to as
+### "drivers" here). The API will load-balance among drivers in the standard
+### pool; if one standard driver fails, the next one will be tried.
+###
+### Each driver URL will have its hostname resolved to an IP address. If a domain
+### name resolves to multiple IP addresses, the API will load-balance across each
+### IP address.
+###
+### This behavior is provided for convenience, and in a production environment
+### other tools can be used, such as HAProxy.
+###
+### Below is a new Speech Engine ("driver") in the "standard" pool.
+[[driver_pool.standard]]
+### Host to connect to. If you are using a different method of orchestrating,
+### then adjust the IP address accordingly.
+###
+### WARN: This must be HTTPS.
+###
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+url = "https://engine-en:8080/v2"
+### Factor to increase the timeout by for each additional retry (for
+### exponential backoff).
+timeout_backoff = 1.2
+
+### Before attempting a retry, sleep for this long (in seconds)
+retry_sleep = "2s"
+### Factor to increase the retry sleep by for each additional retry (for
+### exponential backoff).
+retry_backoff = 1.6
+
+### Maximum response to deserialize from Driver (in bytes)
+max_response_size = 1073741824 # 1GB

--- a/common/license_proxy_deploy/api.aura-2-en.toml
+++ b/common/license_proxy_deploy/api.aura-2-en.toml
@@ -88,6 +88,9 @@ format_entity_tags = false # or true
 ### Enables streaming TTS *if* a valid Aura TTS model is available
 speak_streaming = true # or false
 
+### Toggles usage data redaction; set to false to disable redaction of usage data; defaults to true if not present
+# redact_usage = true # or false
+
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard
 ### pool; if one standard driver fails, the next one will be tried.

--- a/common/license_proxy_deploy/api.aura-2-es.toml
+++ b/common/license_proxy_deploy/api.aura-2-es.toml
@@ -88,6 +88,9 @@ format_entity_tags = false # or true
 ### Enables streaming TTS *if* a valid Aura TTS model is available
 speak_streaming = true # or false
 
+### Toggles usage data redaction; set to false to disable redaction of usage data; defaults to true if not present
+# redact_usage = true # or false
+
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard
 ### pool; if one standard driver fails, the next one will be tried.

--- a/common/license_proxy_deploy/api.aura-2-es.toml
+++ b/common/license_proxy_deploy/api.aura-2-es.toml
@@ -1,0 +1,123 @@
+### Keep in mind that all paths are in-container paths, and do not need to exist
+### on the host machine.
+
+
+### Configure license validation by passing in a DEEPGRAM_API_KEY environment variable
+### See https://developers.deepgram.com/docs/deploy-deepgram-services#credentials
+[license]
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+server_url = ["https://license-proxy:8443", "https://license.deepgram.com"]
+
+
+### Configure how the API will listen for your requests
+[server]
+### The base URL (prefix) for requests to the API.
+base_url = "/v1"
+### The IP address to listen on. Since this is likely running in a Docker
+### container, you will probably want to listen on all interfaces.
+host = "0.0.0.0"
+### The port to listen on
+port = 8080
+
+### How long to wait for a connection to a callback URL.
+callback_conn_timeout = "1s"
+### How long to wait for a response to a callback URL.
+callback_timeout = "10s"
+
+### How long to wait for a connection to a fetch URL.
+fetch_conn_timeout = "1s"
+### How long to wait for a response to a fetch URL.
+fetch_timeout = "60s"
+
+
+### By default, the API listens over HTTP. By passing both a certificate
+### and a key file, the API will instead listen over HTTPS.
+###
+### This performs TLS termination only, and does not provide any
+### additional authentication.
+[server.https]
+# cert_file = "/path/to/cert.pem"
+# key_file = "/path/to/key.pem"
+
+
+### Specify custom DNS resolution options.
+[resolver]
+### Specify custom domain name server(s).
+### Format is "{IP} {PORT} {PROTOCOL (tcp or udp)}"
+# nameservers = ["127.0.0.1 53 udp"]
+
+### If specifying a custom DNS nameserver, set the DNS TTL value.
+# max_ttl = 10
+
+
+### Limit the number of active requests handled by a single API container.
+### If additional requests beyond the limit are sent, API will return
+### a 429 HTTP status code. Default is no limit.
+[concurrency_limit]
+# active_requests =
+
+
+### Enable ancillary features
+[features]
+### Enables topic detection *if* a valid topic detection model is available
+topic_detection = true # or false
+
+### Enables summarization *if* a valid summarization model is available
+summarization = true # or false
+
+### Enables pre-recorded entity detection *if* a valid entity detection model is available
+entity_detection = false # or true
+
+### Enables pre-recorded entity-based redaction *if* a valid entity detection model is available
+entity_redaction = false # or true
+
+### Enables pre-recorded entity formatting *if* a valid NER model is available
+format_entity_tags = false # or true
+
+### If API is receiving requests faster than Engine can process them, a request
+### queue will form. By default, this queue is stored in memory. Under high load,
+### the queue may grow too large and cause Out-Of-Memory errors. To avoid this,
+### set a disk_buffer_path to buffer the overflow on the request queue to disk.
+###
+### WARN: This is only to temporarily buffer requests during high load.
+### If there is not enough Engine capacity to process the queued requests over time,
+### the queue (and response time) will grow indefinitely.
+# disk_buffer_path = "/path/to/disk/buffer/directory"
+
+### Enables streaming TTS *if* a valid Aura TTS model is available
+speak_streaming = true # or false
+
+### Configure the backend pool of speech engines (generically referred to as
+### "drivers" here). The API will load-balance among drivers in the standard
+### pool; if one standard driver fails, the next one will be tried.
+###
+### Each driver URL will have its hostname resolved to an IP address. If a domain
+### name resolves to multiple IP addresses, the API will load-balance across each
+### IP address.
+###
+### This behavior is provided for convenience, and in a production environment
+### other tools can be used, such as HAProxy.
+###
+### Below is a new Speech Engine ("driver") in the "standard" pool.
+[[driver_pool.standard]]
+### Host to connect to. If you are using a different method of orchestrating,
+### then adjust the IP address accordingly.
+###
+### WARN: This must be HTTPS.
+###
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+url = "https://engine-es:8080/v2"
+### Factor to increase the timeout by for each additional retry (for
+### exponential backoff).
+timeout_backoff = 1.2
+
+### Before attempting a retry, sleep for this long (in seconds)
+retry_sleep = "2s"
+### Factor to increase the retry sleep by for each additional retry (for
+### exponential backoff).
+retry_backoff = 1.6
+
+### Maximum response to deserialize from Driver (in bytes)
+max_response_size = 1073741824 # 1GB

--- a/common/license_proxy_deploy/api.toml
+++ b/common/license_proxy_deploy/api.toml
@@ -88,6 +88,9 @@ format_entity_tags = false # or true
 ### Enables streaming TTS *if* a valid Aura TTS model is available
 speak_streaming = true # or false
 
+### Toggles usage data redaction; set to false to disable redaction of usage data; defaults to true if not present
+# redact_usage = true # or false
+
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard
 ### pool; if one standard driver fails, the next one will be tried.

--- a/common/license_proxy_deploy/engine.aura-2-en.toml
+++ b/common/license_proxy_deploy/engine.aura-2-en.toml
@@ -1,0 +1,79 @@
+### Keep in mind that all paths are in-container paths and do not need to exist
+### on the host machine.
+
+### Limit the number of active requests handled by a single Engine container.
+### Engine will reject additional requests from API beyond this limit, and the
+### API container will continue with the retry logic configured in `api.toml`.
+###
+### The default is no limit.
+# max_active_requests =
+
+
+### Configure license validation by passing in a DEEPGRAM_API_KEY environment variable
+### See https://developers.deepgram.com/docs/deploy-deepgram-services#credentials
+[license]
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+server_url = ["https://license-proxy:8443", "https://license.deepgram.com"]
+
+
+### Configure the server to listen for requests from the API.
+[server]
+### The IP address to listen on. Since this is likely running in a Docker
+### container, you will probably want to listen on all interfaces.
+host = "0.0.0.0"
+### The port to listen on
+port = 8080
+
+
+### To support metrics we need to expose an Engine endpoint.
+### See https://developers.deepgram.com/docs/metrics-guide#deepgram-engine
+[metrics_server]
+host = "0.0.0.0"
+port = 9991
+
+
+[model_manager]
+### The number of models to have concurrently loaded in system memory.
+### If managing a deployment with dozens of models this setting will
+### help prevent instances where models consume too much memory and
+### offload the models to disk as needed on a least-recently-used basis.
+###
+### The default is no limit.
+# max_concurrently_loaded_models = 20
+
+### Inference models. You can place these in one or multiple directories.
+search_paths = ["/models"]
+
+
+### Enable ancillary features
+[features]
+### Allow multichannel requests by setting this to true, set to false to disable
+multichannel = true # or false
+### Enables language detection *if* a valid language detection model is available
+language_detection = true # or false
+### Enables streaming entity formatting *if* a valid NER model is available
+streaming_ner = false # or true
+
+### Size of audio chunks to process in seconds.
+[chunking.batch]
+# min_duration =
+# max_duration =
+[chunking.streaming]
+# min_duration =
+# max_duration =
+
+### How often to return interim results, in seconds. Default is 1.0s.
+###
+### This value may be lowered to increase the frequency of interim results.
+### However, this may cause a signficant decrease in number of concurrent
+### streams supported by a single GPU. Please contact your Deepgram Account
+### representative for more details.
+# step = 1.0
+
+
+### Engine will automatically enable half precision operations if your GPU supports
+### them. You can explicitly enable or disable this behavior with the state parameter
+### which supports enabled, disabled, and auto (the default).
+[half_precision]
+# state = "disabled" # or "enabled" or "auto"

--- a/common/license_proxy_deploy/engine.aura-2-es.toml
+++ b/common/license_proxy_deploy/engine.aura-2-es.toml
@@ -1,0 +1,79 @@
+### Keep in mind that all paths are in-container paths and do not need to exist
+### on the host machine.
+
+### Limit the number of active requests handled by a single Engine container.
+### Engine will reject additional requests from API beyond this limit, and the
+### API container will continue with the retry logic configured in `api.toml`.
+###
+### The default is no limit.
+# max_active_requests =
+
+
+### Configure license validation by passing in a DEEPGRAM_API_KEY environment variable
+### See https://developers.deepgram.com/docs/deploy-deepgram-services#credentials
+[license]
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+server_url = ["https://license-proxy:8443", "https://license.deepgram.com"]
+
+
+### Configure the server to listen for requests from the API.
+[server]
+### The IP address to listen on. Since this is likely running in a Docker
+### container, you will probably want to listen on all interfaces.
+host = "0.0.0.0"
+### The port to listen on
+port = 8080
+
+
+### To support metrics we need to expose an Engine endpoint.
+### See https://developers.deepgram.com/docs/metrics-guide#deepgram-engine
+[metrics_server]
+host = "0.0.0.0"
+port = 9992
+
+
+[model_manager]
+### The number of models to have concurrently loaded in system memory.
+### If managing a deployment with dozens of models this setting will
+### help prevent instances where models consume too much memory and
+### offload the models to disk as needed on a least-recently-used basis.
+###
+### The default is no limit.
+# max_concurrently_loaded_models = 20
+
+### Inference models. You can place these in one or multiple directories.
+search_paths = ["/models"]
+
+
+### Enable ancillary features
+[features]
+### Allow multichannel requests by setting this to true, set to false to disable
+multichannel = true # or false
+### Enables language detection *if* a valid language detection model is available
+language_detection = true # or false
+### Enables streaming entity formatting *if* a valid NER model is available
+streaming_ner = false # or true
+
+### Size of audio chunks to process in seconds.
+[chunking.batch]
+# min_duration =
+# max_duration =
+[chunking.streaming]
+# min_duration =
+# max_duration =
+
+### How often to return interim results, in seconds. Default is 1.0s.
+###
+### This value may be lowered to increase the frequency of interim results.
+### However, this may cause a signficant decrease in number of concurrent
+### streams supported by a single GPU. Please contact your Deepgram Account
+### representative for more details.
+# step = 1.0
+
+
+### Engine will automatically enable half precision operations if your GPU supports
+### them. You can explicitly enable or disable this behavior with the state parameter
+### which supports enabled, disabled, and auto (the default).
+[half_precision]
+# state = "disabled" # or "enabled" or "auto"

--- a/common/standard_deploy/api.aura-2-en.toml
+++ b/common/standard_deploy/api.aura-2-en.toml
@@ -1,0 +1,123 @@
+### Keep in mind that all paths are in-container paths, and do not need to exist
+### on the host machine.
+
+
+### Configure license validation by passing in a DEEPGRAM_API_KEY environment variable
+### See https://developers.deepgram.com/docs/deploy-deepgram-services#credentials
+[license]
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+server_url = ["https://license-proxy:8443", "https://license.deepgram.com"]
+
+
+### Configure how the API will listen for your requests
+[server]
+### The base URL (prefix) for requests to the API.
+base_url = "/v1"
+### The IP address to listen on. Since this is likely running in a Docker
+### container, you will probably want to listen on all interfaces.
+host = "0.0.0.0"
+### The port to listen on
+port = 8080
+
+### How long to wait for a connection to a callback URL.
+callback_conn_timeout = "1s"
+### How long to wait for a response to a callback URL.
+callback_timeout = "10s"
+
+### How long to wait for a connection to a fetch URL.
+fetch_conn_timeout = "1s"
+### How long to wait for a response to a fetch URL.
+fetch_timeout = "60s"
+
+
+### By default, the API listens over HTTP. By passing both a certificate
+### and a key file, the API will instead listen over HTTPS.
+###
+### This performs TLS termination only, and does not provide any
+### additional authentication.
+[server.https]
+# cert_file = "/path/to/cert.pem"
+# key_file = "/path/to/key.pem"
+
+
+### Specify custom DNS resolution options.
+[resolver]
+### Specify custom domain name server(s).
+### Format is "{IP} {PORT} {PROTOCOL (tcp or udp)}"
+# nameservers = ["127.0.0.1 53 udp"]
+
+### If specifying a custom DNS nameserver, set the DNS TTL value.
+# max_ttl = 10
+
+
+### Limit the number of active requests handled by a single API container.
+### If additional requests beyond the limit are sent, API will return
+### a 429 HTTP status code. Default is no limit.
+[concurrency_limit]
+# active_requests =
+
+
+### Enable ancillary features
+[features]
+### Enables topic detection *if* a valid topic detection model is available
+topic_detection = true # or false
+
+### Enables summarization *if* a valid summarization model is available
+summarization = true # or false
+
+### Enables pre-recorded entity detection *if* a valid entity detection model is available
+entity_detection = false # or true
+
+### Enables pre-recorded entity-based redaction *if* a valid entity detection model is available
+entity_redaction = false # or true
+
+### Enables pre-recorded entity formatting *if* a valid NER model is available
+format_entity_tags = false # or true
+
+### If API is receiving requests faster than Engine can process them, a request
+### queue will form. By default, this queue is stored in memory. Under high load,
+### the queue may grow too large and cause Out-Of-Memory errors. To avoid this,
+### set a disk_buffer_path to buffer the overflow on the request queue to disk.
+###
+### WARN: This is only to temporarily buffer requests during high load.
+### If there is not enough Engine capacity to process the queued requests over time,
+### the queue (and response time) will grow indefinitely.
+# disk_buffer_path = "/path/to/disk/buffer/directory"
+
+### Enables streaming TTS *if* a valid Aura TTS model is available
+speak_streaming = true # or false
+
+### Configure the backend pool of speech engines (generically referred to as
+### "drivers" here). The API will load-balance among drivers in the standard
+### pool; if one standard driver fails, the next one will be tried.
+###
+### Each driver URL will have its hostname resolved to an IP address. If a domain
+### name resolves to multiple IP addresses, the API will load-balance across each
+### IP address.
+###
+### This behavior is provided for convenience, and in a production environment
+### other tools can be used, such as HAProxy.
+###
+### Below is a new Speech Engine ("driver") in the "standard" pool.
+[[driver_pool.standard]]
+### Host to connect to. If you are using a different method of orchestrating,
+### then adjust the IP address accordingly.
+###
+### WARN: This must be HTTPS.
+###
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+url = "https://engine-en:8080/v2"
+### Factor to increase the timeout by for each additional retry (for
+### exponential backoff).
+timeout_backoff = 1.2
+
+### Before attempting a retry, sleep for this long (in seconds)
+retry_sleep = "2s"
+### Factor to increase the retry sleep by for each additional retry (for
+### exponential backoff).
+retry_backoff = 1.6
+
+### Maximum response to deserialize from Driver (in bytes)
+max_response_size = 1073741824 # 1GB

--- a/common/standard_deploy/api.aura-2-en.toml
+++ b/common/standard_deploy/api.aura-2-en.toml
@@ -88,6 +88,9 @@ format_entity_tags = false # or true
 ### Enables streaming TTS *if* a valid Aura TTS model is available
 speak_streaming = true # or false
 
+### Toggles usage data redaction; set to false to disable redaction of usage data; defaults to true if not present
+# redact_usage = true # or false
+
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard
 ### pool; if one standard driver fails, the next one will be tried.

--- a/common/standard_deploy/api.aura-2-es.toml
+++ b/common/standard_deploy/api.aura-2-es.toml
@@ -88,6 +88,9 @@ format_entity_tags = false # or true
 ### Enables streaming TTS *if* a valid Aura TTS model is available
 speak_streaming = true # or false
 
+### Toggles usage data redaction; set to false to disable redaction of usage data; defaults to true if not present
+# redact_usage = true # or false
+
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard
 ### pool; if one standard driver fails, the next one will be tried.

--- a/common/standard_deploy/api.aura-2-es.toml
+++ b/common/standard_deploy/api.aura-2-es.toml
@@ -1,0 +1,123 @@
+### Keep in mind that all paths are in-container paths, and do not need to exist
+### on the host machine.
+
+
+### Configure license validation by passing in a DEEPGRAM_API_KEY environment variable
+### See https://developers.deepgram.com/docs/deploy-deepgram-services#credentials
+[license]
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+server_url = ["https://license-proxy:8443", "https://license.deepgram.com"]
+
+
+### Configure how the API will listen for your requests
+[server]
+### The base URL (prefix) for requests to the API.
+base_url = "/v1"
+### The IP address to listen on. Since this is likely running in a Docker
+### container, you will probably want to listen on all interfaces.
+host = "0.0.0.0"
+### The port to listen on
+port = 8080
+
+### How long to wait for a connection to a callback URL.
+callback_conn_timeout = "1s"
+### How long to wait for a response to a callback URL.
+callback_timeout = "10s"
+
+### How long to wait for a connection to a fetch URL.
+fetch_conn_timeout = "1s"
+### How long to wait for a response to a fetch URL.
+fetch_timeout = "60s"
+
+
+### By default, the API listens over HTTP. By passing both a certificate
+### and a key file, the API will instead listen over HTTPS.
+###
+### This performs TLS termination only, and does not provide any
+### additional authentication.
+[server.https]
+# cert_file = "/path/to/cert.pem"
+# key_file = "/path/to/key.pem"
+
+
+### Specify custom DNS resolution options.
+[resolver]
+### Specify custom domain name server(s).
+### Format is "{IP} {PORT} {PROTOCOL (tcp or udp)}"
+# nameservers = ["127.0.0.1 53 udp"]
+
+### If specifying a custom DNS nameserver, set the DNS TTL value.
+# max_ttl = 10
+
+
+### Limit the number of active requests handled by a single API container.
+### If additional requests beyond the limit are sent, API will return
+### a 429 HTTP status code. Default is no limit.
+[concurrency_limit]
+# active_requests =
+
+
+### Enable ancillary features
+[features]
+### Enables topic detection *if* a valid topic detection model is available
+topic_detection = true # or false
+
+### Enables summarization *if* a valid summarization model is available
+summarization = true # or false
+
+### Enables pre-recorded entity detection *if* a valid entity detection model is available
+entity_detection = false # or true
+
+### Enables pre-recorded entity-based redaction *if* a valid entity detection model is available
+entity_redaction = false # or true
+
+### Enables pre-recorded entity formatting *if* a valid NER model is available
+format_entity_tags = false # or true
+
+### If API is receiving requests faster than Engine can process them, a request
+### queue will form. By default, this queue is stored in memory. Under high load,
+### the queue may grow too large and cause Out-Of-Memory errors. To avoid this,
+### set a disk_buffer_path to buffer the overflow on the request queue to disk.
+###
+### WARN: This is only to temporarily buffer requests during high load.
+### If there is not enough Engine capacity to process the queued requests over time,
+### the queue (and response time) will grow indefinitely.
+# disk_buffer_path = "/path/to/disk/buffer/directory"
+
+### Enables streaming TTS *if* a valid Aura TTS model is available
+speak_streaming = true # or false
+
+### Configure the backend pool of speech engines (generically referred to as
+### "drivers" here). The API will load-balance among drivers in the standard
+### pool; if one standard driver fails, the next one will be tried.
+###
+### Each driver URL will have its hostname resolved to an IP address. If a domain
+### name resolves to multiple IP addresses, the API will load-balance across each
+### IP address.
+###
+### This behavior is provided for convenience, and in a production environment
+### other tools can be used, such as HAProxy.
+###
+### Below is a new Speech Engine ("driver") in the "standard" pool.
+[[driver_pool.standard]]
+### Host to connect to. If you are using a different method of orchestrating,
+### then adjust the IP address accordingly.
+###
+### WARN: This must be HTTPS.
+###
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+url = "https://engine-es:8080/v2"
+### Factor to increase the timeout by for each additional retry (for
+### exponential backoff).
+timeout_backoff = 1.2
+
+### Before attempting a retry, sleep for this long (in seconds)
+retry_sleep = "2s"
+### Factor to increase the retry sleep by for each additional retry (for
+### exponential backoff).
+retry_backoff = 1.6
+
+### Maximum response to deserialize from Driver (in bytes)
+max_response_size = 1073741824 # 1GB

--- a/common/standard_deploy/api.toml
+++ b/common/standard_deploy/api.toml
@@ -86,6 +86,9 @@ format_entity_tags = false # or true
 ### Enables streaming TTS *if* a valid Aura TTS model is available
 speak_streaming = true # or false
 
+### Toggles usage data redaction; set to false to disable redaction of usage data; defaults to true if not present
+# redact_usage = true # or false
+
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard
 ### pool; if one standard driver fails, the next one will be tried.

--- a/common/standard_deploy/engine.aura-2-en.toml
+++ b/common/standard_deploy/engine.aura-2-en.toml
@@ -1,0 +1,79 @@
+### Keep in mind that all paths are in-container paths and do not need to exist
+### on the host machine.
+
+### Limit the number of active requests handled by a single Engine container.
+### Engine will reject additional requests from API beyond this limit, and the
+### API container will continue with the retry logic configured in `api.toml`.
+###
+### The default is no limit.
+# max_active_requests =
+
+
+### Configure license validation by passing in a DEEPGRAM_API_KEY environment variable
+### See https://developers.deepgram.com/docs/deploy-deepgram-services#credentials
+[license]
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+server_url = ["https://license-proxy:8443", "https://license.deepgram.com"]
+
+
+### Configure the server to listen for requests from the API.
+[server]
+### The IP address to listen on. Since this is likely running in a Docker
+### container, you will probably want to listen on all interfaces.
+host = "0.0.0.0"
+### The port to listen on
+port = 8080
+
+
+### To support metrics we need to expose an Engine endpoint.
+### See https://developers.deepgram.com/docs/metrics-guide#deepgram-engine
+[metrics_server]
+host = "0.0.0.0"
+port = 9991
+
+
+[model_manager]
+### The number of models to have concurrently loaded in system memory.
+### If managing a deployment with dozens of models this setting will
+### help prevent instances where models consume too much memory and
+### offload the models to disk as needed on a least-recently-used basis.
+###
+### The default is no limit.
+# max_concurrently_loaded_models = 20
+
+### Inference models. You can place these in one or multiple directories.
+search_paths = ["/models"]
+
+
+### Enable ancillary features
+[features]
+### Allow multichannel requests by setting this to true, set to false to disable
+multichannel = true # or false
+### Enables language detection *if* a valid language detection model is available
+language_detection = true # or false
+### Enables streaming entity formatting *if* a valid NER model is available
+streaming_ner = false # or true
+
+### Size of audio chunks to process in seconds.
+[chunking.batch]
+# min_duration =
+# max_duration =
+[chunking.streaming]
+# min_duration =
+# max_duration =
+
+### How often to return interim results, in seconds. Default is 1.0s.
+###
+### This value may be lowered to increase the frequency of interim results.
+### However, this may cause a signficant decrease in number of concurrent
+### streams supported by a single GPU. Please contact your Deepgram Account
+### representative for more details.
+# step = 1.0
+
+
+### Engine will automatically enable half precision operations if your GPU supports
+### them. You can explicitly enable or disable this behavior with the state parameter
+### which supports enabled, disabled, and auto (the default).
+[half_precision]
+# state = "disabled" # or "enabled" or "auto"

--- a/common/standard_deploy/engine.aura-2-es.toml
+++ b/common/standard_deploy/engine.aura-2-es.toml
@@ -1,0 +1,79 @@
+### Keep in mind that all paths are in-container paths and do not need to exist
+### on the host machine.
+
+### Limit the number of active requests handled by a single Engine container.
+### Engine will reject additional requests from API beyond this limit, and the
+### API container will continue with the retry logic configured in `api.toml`.
+###
+### The default is no limit.
+# max_active_requests =
+
+
+### Configure license validation by passing in a DEEPGRAM_API_KEY environment variable
+### See https://developers.deepgram.com/docs/deploy-deepgram-services#credentials
+[license]
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+server_url = ["https://license-proxy:8443", "https://license.deepgram.com"]
+
+
+### Configure the server to listen for requests from the API.
+[server]
+### The IP address to listen on. Since this is likely running in a Docker
+### container, you will probably want to listen on all interfaces.
+host = "0.0.0.0"
+### The port to listen on
+port = 8080
+
+
+### To support metrics we need to expose an Engine endpoint.
+### See https://developers.deepgram.com/docs/metrics-guide#deepgram-engine
+[metrics_server]
+host = "0.0.0.0"
+port = 9992
+
+
+[model_manager]
+### The number of models to have concurrently loaded in system memory.
+### If managing a deployment with dozens of models this setting will
+### help prevent instances where models consume too much memory and
+### offload the models to disk as needed on a least-recently-used basis.
+###
+### The default is no limit.
+# max_concurrently_loaded_models = 20
+
+### Inference models. You can place these in one or multiple directories.
+search_paths = ["/models"]
+
+
+### Enable ancillary features
+[features]
+### Allow multichannel requests by setting this to true, set to false to disable
+multichannel = true # or false
+### Enables language detection *if* a valid language detection model is available
+language_detection = true # or false
+### Enables streaming entity formatting *if* a valid NER model is available
+streaming_ner = false # or true
+
+### Size of audio chunks to process in seconds.
+[chunking.batch]
+# min_duration =
+# max_duration =
+[chunking.streaming]
+# min_duration =
+# max_duration =
+
+### How often to return interim results, in seconds. Default is 1.0s.
+###
+### This value may be lowered to increase the frequency of interim results.
+### However, this may cause a signficant decrease in number of concurrent
+### streams supported by a single GPU. Please contact your Deepgram Account
+### representative for more details.
+# step = 1.0
+
+
+### Engine will automatically enable half precision operations if your GPU supports
+### them. You can explicitly enable or disable this behavior with the state parameter
+### which supports enabled, disabled, and auto (the default).
+[half_precision]
+# state = "disabled" # or "enabled" or "auto"

--- a/docker/docker-compose.aura-2.yml
+++ b/docker/docker-compose.aura-2.yml
@@ -10,8 +10,7 @@ services:
   # The speech API service.
   # English Language Aura-2
   api-en:
-    #image: quay.io/deepgram/self-hosted-api:release-250710
-    image: quay.io/deepgram/stem:1.154.1-self-hosted
+    image: quay.io/deepgram/self-hosted-api:release-250731
 
     # Here we expose the API port to the host machine. The container port
     # (right-hand side) must match the port that the API service is listening
@@ -37,8 +36,7 @@ services:
 
   # Spanish Language Aura-2
   api-es:
-    #image: quay.io/deepgram/self-hosted-api:release-250710
-    image: quay.io/deepgram/stem:1.154.1-self-hosted
+    image: quay.io/deepgram/self-hosted-api:release-250731
 
     # Here we expose the API port to the host machine. The container port
     # (right-hand side) must match the port that the API service is listening
@@ -65,8 +63,7 @@ services:
   # The speech engine service.
   # English Language Aura-2 Driver
   engine-en:
-    #image: quay.io/deepgram/self-hosted-engine:release-250710
-    image: quay.io/deepgram/impeller:3.93.1-self-hosted
+    image: quay.io/deepgram/self-hosted-engine:release-250731
 
     # Utilize a GPU, if available.
     runtime: nvidia
@@ -98,8 +95,7 @@ services:
 
   # Spanish Language Aura-2 Driver
   engine-es:
-    #image: quay.io/deepgram/self-hosted-engine:release-250710
-    image: quay.io/deepgram/impeller:3.93.1-self-hosted
+    image: quay.io/deepgram/self-hosted-engine:release-250731
 
     # Utilize a GPU, if available.
     runtime: nvidia
@@ -131,7 +127,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-250710
+    image: quay.io/deepgram/self-hosted-license-proxy:release-250731
 
     # Here we expose the License Proxy status port to the host machine. The container port
     # (right-hand side) must match the port that the License Proxy service is listening

--- a/docker/docker-compose.aura-2.yml
+++ b/docker/docker-compose.aura-2.yml
@@ -1,0 +1,152 @@
+# Make sure to replace placeholder paths to config files and model directories
+
+x-env-vars: &env
+  # Make sure you `export` your self-hosted API key secret in your local environment
+  # Be sure to use the &env anchor inside an 'environment' mapping for a given service
+  DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
+  DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "docker-compose"
+
+services:
+  # The speech API service.
+  # English Language Aura-2
+  api-en:
+    #image: quay.io/deepgram/self-hosted-api:release-250710
+    image: quay.io/deepgram/stem:1.154.1-self-hosted
+
+    # Here we expose the API port to the host machine. The container port
+    # (right-hand side) must match the port that the API service is listening
+    # on (from its configuration file).
+    ports:
+      - "8080:8080"
+
+    environment:
+      <<: *env
+
+    # The path on the left of the colon ':' should point to files/directories on the host machine.
+    # The path on the right of the colon ':' is an in-container path. It must match the path
+    #     specified in the `command` header below.
+    volumes:
+      - "./api.aura-2-en.toml:/api.toml:ro,Z"
+
+    # Invoke the API server
+    command: -v serve /api.toml
+
+    # Make sure the License Proxy is available for licensing
+    depends_on:
+      - license-proxy
+
+  # Spanish Language Aura-2
+  api-es:
+    #image: quay.io/deepgram/self-hosted-api:release-250710
+    image: quay.io/deepgram/stem:1.154.1-self-hosted
+
+    # Here we expose the API port to the host machine. The container port
+    # (right-hand side) must match the port that the API service is listening
+    # on (from its configuration file).
+    ports:
+      - "8081:8080"
+
+    environment:
+      <<: *env
+
+    # The path on the left of the colon ':' should point to files/directories on the host machine.
+    # The path on the right of the colon ':' is an in-container path. It must match the path
+    #     specified in the `command` header below.
+    volumes:
+      - "./api.aura-2-es.toml:/api.toml:ro,Z"
+
+    # Invoke the API server
+    command: -v serve /api.toml
+
+    # Make sure the License Proxy is available for licensing
+    depends_on:
+      - license-proxy
+
+  # The speech engine service.
+  # English Language Aura-2 Driver
+  engine-en:
+    #image: quay.io/deepgram/self-hosted-engine:release-250710
+    image: quay.io/deepgram/impeller:3.93.1-self-hosted
+
+    # Utilize a GPU, if available.
+    runtime: nvidia
+
+    ports:
+      - "9991:9991"
+
+    environment:
+      <<: *env
+      IMPELLER_AURA2_MAX_BATCH_SIZE: 8
+      IMPELLER_AURA2_T2C_UUID: "15ef8614-52cb-4cd3-a641-d68249c15d53"
+      IMPELLER_AURA2_C2A_UUID: "2e5096c7-7bf1-435e-bbdd-f673f88d0ebd"
+      CUDA_VISIBLE_DEVICES: 0,1
+
+    # The path on the left of the colon ':' should point to files/directories on the host machine.
+    # The path on the right of the colon ':' is an in-container path.
+    volumes:
+      # In-container models path below must match the one specified in the Engine configuration file. The default location is "/models"
+      - "../models:/models:ro,Z"
+      # In-container config path below must match the path specified in the `command` header below.
+      - "./engine.aura-2-en.toml:/engine.toml:ro,Z"
+
+    # Invoke the Engine service
+    command: -v serve /engine.toml
+
+    # Make sure the License Proxy is available for licensing
+    depends_on:
+      - license-proxy
+
+  # Spanish Language Aura-2 Driver
+  engine-es:
+    #image: quay.io/deepgram/self-hosted-engine:release-250710
+    image: quay.io/deepgram/impeller:3.93.1-self-hosted
+
+    # Utilize a GPU, if available.
+    runtime: nvidia
+
+    ports:
+      - "9992:9992"
+
+    environment:
+      <<: *env
+      IMPELLER_AURA2_MAX_BATCH_SIZE: 8
+      IMPELLER_AURA2_T2C_UUID: "5d53d105-c6a4-47f5-b670-61adb6e8a880"
+      IMPELLER_AURA2_C2A_UUID: "4d5c93ad-9e20-4ebf-a1f0-0fb88ac73ef5"
+      CUDA_VISIBLE_DEVICES: 2,3
+
+    # The path on the left of the colon ':' should point to files/directories on the host machine.
+    # The path on the right of the colon ':' is an in-container path.
+    volumes:
+      # In-container models path below must match the one specified in the Engine configuration file. The default location is "/models"
+      - "../models:/models:ro,Z"
+      # In-container config path below must match the path specified in the `command` header below.
+      - "./engine.aura-2-es.toml:/engine.toml:ro,Z"
+
+    # Invoke the Engine service
+    command: -v serve /engine.toml
+
+    # Make sure the License Proxy is available for licensing
+    depends_on:
+      - license-proxy
+
+  # The service to validate your Deepgram license
+  license-proxy:
+    image: quay.io/deepgram/self-hosted-license-proxy:release-250710
+
+    # Here we expose the License Proxy status port to the host machine. The container port
+    # (right-hand side) must match the port that the License Proxy service is listening
+    # on (from its configuration file).
+    ports:
+      - "8089:8080"
+
+    environment:
+      <<: *env
+
+    # The path on the left of the colon ':' should point to files/directories on the host machine.
+    # The path on the right of the colon ':' is an in-container path. It must match the path
+    #     specified in the `command` header below.
+    volumes:
+      - "./license-proxy.toml:/license-proxy.toml:ro,Z"
+
+    # Invoke the License Proxy service
+    command: -v serve /license-proxy.toml

--- a/docker/docker-compose.license-proxy.yml
+++ b/docker/docker-compose.license-proxy.yml
@@ -9,7 +9,7 @@ x-env: &env
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-250710
+    image: quay.io/deepgram/self-hosted-api:release-250731
 
     # Here we expose the API port to the host machine. The container port
     # (right-hand side) must match the port that the API service is listening
@@ -34,7 +34,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-250710
+    image: quay.io/deepgram/self-hosted-engine:release-250731
 
     # Utilize a GPU, if available.
     runtime: nvidia
@@ -61,7 +61,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-250710
+    image: quay.io/deepgram/self-hosted-license-proxy:release-250731
 
     # Here we expose the License Proxy status port to the host machine. The container port
     # (right-hand side) must match the port that the License Proxy service is listening

--- a/docker/docker-compose.standard.yml
+++ b/docker/docker-compose.standard.yml
@@ -9,7 +9,7 @@ x-env: &env
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-250710
+    image: quay.io/deepgram/self-hosted-api:release-250731
 
     # Here we expose the API port to the host machine. The container port
     # (right-hand side) must match the port that the API service is listening
@@ -30,7 +30,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-250710
+    image: quay.io/deepgram/self-hosted-engine:release-250731
 
     # Utilize a GPU, if available.
     runtime: nvidia

--- a/podman/podman-compose.license-proxy.yml
+++ b/podman/podman-compose.license-proxy.yml
@@ -3,7 +3,7 @@
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-250710
+    image: quay.io/deepgram/self-hosted-api:release-250731
 
     # Here we expose the API port to the host machine. The container port
     # (right-hand side) must match the port that the API service is listening
@@ -31,7 +31,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-250710
+    image: quay.io/deepgram/self-hosted-engine:release-250731
 
     # Utilize a GPU, if available.
     devices:
@@ -62,7 +62,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-250710
+    image: quay.io/deepgram/self-hosted-license-proxy:release-250731
 
     # Here we expose the License Proxy status port to the host machine. The container port
     # (right-hand side) must match the port that the License Proxy service is listening

--- a/podman/podman-compose.standard.yml
+++ b/podman/podman-compose.standard.yml
@@ -3,7 +3,7 @@
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-250710
+    image: quay.io/deepgram/self-hosted-api:release-250731
 
     # Here we expose the API port to the host machine. The container port
     # (right-hand side) must match the port that the API service is listening
@@ -27,7 +27,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-250710
+    image: quay.io/deepgram/self-hosted-engine:release-250731
 
     # Utilize a GPU, if available.
     devices:


### PR DESCRIPTION
 ## Proposed changes

  This PR updates all container image tags to the latest release-250731 and cleans up the Aura-2
  configuration files to use production container image names.

  Key changes:
  - Updates Chart version to 0.16.0 and appVersion to release-250731
  - Updates all container image tags across docker-compose and podman-compose files
  - Updates Aura-2 configuration to use production container image names
  - Removes commented lines from docker-compose.aura-2.yml

  ## Types of changes

  What types of changes does your code introduce to the Deepgram self-hosted resources?
  _Put an `x` in the boxes that apply_

  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
  - [ ] Documentation update or tests (if none of the other choices apply)

  ## Checklist

  _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're
  unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of
  what we are going to look for before merging your code._

  - [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
  - [ ] I have tested my changes in my local self-hosted environment
    - Please describe your testing setup and methodology here
  - [ ] I have added necessary documentation (if appropriate)

  ## Further comments

  This update ensures that the Aura-2 configuration uses the same production container images as the
  standard deployment, maintaining consistency across all deployment methods while updating to the
  latest release version.