### PR TITLE
Fixes Issue 79 -- Incorrect securityContext template references in API and Engine deployments

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+### Fixed
+
+- Fixed securityContext template references for API and Engine deployments
+- Fixed securityContext documentation comments
+
 ## [0.17.0] - 2025-08-14
 
 ### Added

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -263,7 +263,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | engine.resources | object | `` | Configure resource limits per Engine container. See [Deepgram's documentation](https://developers.deepgram.com/docs/self-hosted-deployment-environments#engine) for more details. |
 | engine.resources.limits.gpu | int | `1` | gpu maps to the nvidia.com/gpu resource parameter |
 | engine.resources.requests.gpu | int | `1` | gpu maps to the nvidia.com/gpu resource parameter |
-| engine.securityContext | object | `{}` | [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for API pods. |
+| engine.securityContext | object | `{}` | [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for Engine pods. |
 | engine.server | object | `` | Configure Engine containers to listen for requests from API containers. |
 | engine.server.host | string | `"0.0.0.0"` | host is the IP address to listen on for inference requests. You will want to listen on all interfaces to interact with other pods in the cluster. |
 | engine.server.port | int | `8080` | port to listen on for inference requests |
@@ -301,7 +301,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | licenseProxy.namePrefix | string | `"deepgram-license-proxy"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram License Proxy containers. |
 | licenseProxy.readinessProbe | object | `` | Readiness probe customization for License Proxy pods. |
 | licenseProxy.resources | object | `` | Configure resource limits per License Proxy container. See [Deepgram's documentation](https://developers.deepgram.com/docs/license-proxy#system-requirements) for more details. |
-| licenseProxy.securityContext | object | `{}` | [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for API pods. |
+| licenseProxy.securityContext | object | `{}` | [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for License Proxy pods. |
 | licenseProxy.server | object | `` | Configure how the license proxy will listen for licensing requests. |
 | licenseProxy.server.baseUrl | string | `"/"` | baseUrl is the prefix for incoming license verification requests. |
 | licenseProxy.server.host | string | `"0.0.0.0"` | host is the IP address to listen on. You will want to listen on all interfaces to interact with other pods in the cluster. |

--- a/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
@@ -42,7 +42,7 @@ spec:
       tolerations:
         {{- toYaml .Values.api.tolerations | nindent 8 }}
       securityContext:
-        {{- toYaml .Values.licenseProxy.securityContext | nindent 8 }}
+        {{- toYaml .Values.api.securityContext | nindent 8 }}
       {{- if or .Values.api.serviceAccount.create .Values.api.serviceAccount.name }}
       serviceAccountName: {{ default (printf "%s-sa" .Values.api.namePrefix) .Values.api.serviceAccount.name }}
       {{- end }}

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -42,7 +42,7 @@ spec:
       tolerations:
         {{- toYaml .Values.engine.tolerations | nindent 8 }}
       securityContext:
-        {{- toYaml .Values.licenseProxy.securityContext | nindent 8 }}
+        {{- toYaml .Values.engine.securityContext | nindent 8 }}
       {{- if or .Values.engine.serviceAccount.create .Values.engine.serviceAccount.name }}
       serviceAccountName: {{ default (printf "%s-sa" .Values.engine.namePrefix) .Values.engine.serviceAccount.name }}
       {{- end }}

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -354,7 +354,7 @@ engine:
   # to apply to Engine pods.
   tolerations: []
 
-  # -- [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for API pods.
+  # -- [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for Engine pods.
   securityContext: {}
 
   serviceAccount:
@@ -591,7 +591,7 @@ licenseProxy:
   # to apply to License Proxy pods.
   tolerations: []
 
-  # -- [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for API pods.
+  # -- [Security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for License Proxy pods.
   securityContext: {}
 
   serviceAccount:


### PR DESCRIPTION
## Proposed changes

This PR fixes securityContext template references in the API and Engine deployment templates. The templates were referencing .Values.licenseProxy.securityContext instead of their respective .Values.api.securityContext and .Values.engine.securityContext values.

## Types of changes

What types of changes does your code introduce to the Deepgram self-hosted resources?

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] I have tested my changes in my local self-hosted environment
  - I used this chart to install Deepgram in our non-prod k8s cluster, verified correct deployment config and that the application operates correctly
- [X] I have added necessary documentation (if appropriate)

## Further comments
