### PR TITLE
Fix HPA replica conflicts in API and Engine deployments

### DIFF
--- a/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
@@ -17,7 +17,9 @@ spec:
     matchLabels:
       app: deepgram-api
       {{ include "deepgram-self-hosted.selectorLabels" . }}
+  {{- if not .Values.scaling.auto.enabled }}
   replicas: {{ .Values.scaling.replicas.api }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -31,10 +31,12 @@ spec:
       engine-type: {{ $type }}
       {{- end }}
       {{ include "deepgram-self-hosted.selectorLabels" $ }}
+  {{- if not $.Values.scaling.auto.enabled }}
   {{- if $.Values.agent.enabled }}
   replicas: {{ index $.Values.scaling.replicas.engine $type | default 1 }}
   {{- else }}
   replicas: {{ $.Values.scaling.replicas.engine }}
+  {{- end }}
   {{- end }}
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
## Summary

Fixes HPA scaling conflicts by conditionally removing hardcoded `replicas` fields from API and Engine deployments when autoscaling is enabled.

**Closes #86**

## Problem

When `scaling.auto.enabled: true`, deployments have hardcoded `replicas` fields that prevent HPAs from managing scaling properly. This causes:

- Engine deployments stuck at 1 replica despite HPA `minReplicas: 2` 
- API deployments unable to scale based on engine-to-api ratio metrics
- Production auto-scaling failures requiring manual intervention

## Solution  

Added conditional logic to exclude `replicas` field when HPA is enabled:

### Engine Deployment Changes
```yaml
{{- if not $.Values.scaling.auto.enabled }}
{{- if $.Values.agent.enabled }}
replicas: {{ index $.Values.scaling.replicas.engine $type | default 1 }}
{{- else }}
replicas: {{ $.Values.scaling.replicas.engine }}
{{- end }}
{{- end }}
```

### API Deployment Changes  
```yaml
{{- if not .Values.scaling.auto.enabled }}
replicas: {{ .Values.scaling.replicas.api }}
{{- end }}
```

## Testing

✅ **Verified with `helm template`:**

- **HPA Disabled** (`scaling.auto.enabled: false`): Deployments contain `replicas: 1` field ✓
- **HPA Enabled** (`scaling.auto.enabled: true`): Deployments have **no** `replicas` field ✓

```bash
# Test command used:
helm template deepgram-test . \
  --set scaling.auto.enabled=true \
  --set scaling.auto.engine.metrics.requestCapacityRatio=0.5 \
  --set engine.concurrencyLimit.activeRequests=100 \
  --set engine.modelManager.volumes.aws.efs.enabled=true \
  --set engine.modelManager.volumes.aws.efs.fileSystemId=fs-12345 \
  --set global.deepgramSecretRef=test-secret
```

## Impact

- ✅ **Backward Compatible**: No changes when `scaling.auto.enabled: false`
- ✅ **Agent Support**: Works for both standard and agent-enabled deployments  
- ✅ **Production Ready**: Allows proper HPA scaling in production environments
- ✅ **Kubernetes Best Practice**: Follows HPA deployment patterns

## Files Changed

- `templates/api/api.deployment.yaml`: Conditional replicas for API deployment
- `templates/engine/engine.deployment.yaml`: Conditional replicas for Engine deployment(s)

This enables proper auto-scaling for production Deepgram deployments using HPA with metrics like `requestCapacityRatio` and `engineToApiRatio`.