### PR TITLE
Support removing resource limits on engine pods

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Added `externalTrafficPolicy` configuration for LoadBalancer services to control traffic routing behavior
 - Updated sample configurations to demonstrate service configuration options including LoadBalancer security settings
 - Container-level security context support to Helm templates
+- Supported removing resource limits on Engine pods
 
 ### Changed
 

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -108,13 +108,17 @@ spec:
         resources:
           requests:
             memory: "{{ $.Values.engine.resources.requests.memory }}"
-            cpu: "{{ $.Values.engine.resources.requests.cpu }}"
+            cpu: "{{ .Values.engine.resources.requests.cpu }}"
             {{- if gt (int $.Values.engine.resources.requests.gpu) 0 }}
             nvidia.com/gpu: {{ $.Values.engine.resources.requests.gpu }}
             {{- end }}
           limits:
+            {{- if .Values.engine.resources.limits.memory }}
             memory: "{{ $.Values.engine.resources.limits.memory }}"
+            {{- end }}
+            {{- if .Values.engine.resources.limits.cpu }}
             cpu: "{{ $.Values.engine.resources.limits.cpu }}"
+            {{- end }}
             {{- if gt (int $.Values.engine.resources.limits.gpu) 0 }}
             nvidia.com/gpu: {{ $.Values.engine.resources.limits.gpu }}
             {{- end }}

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -113,10 +113,10 @@ spec:
             nvidia.com/gpu: {{ $.Values.engine.resources.requests.gpu }}
             {{- end }}
           limits:
-            {{- if .Values.engine.resources.limits.memory }}
+            {{- if $.Values.engine.resources.limits.memory }}
             memory: "{{ $.Values.engine.resources.limits.memory }}"
             {{- end }}
-            {{- if .Values.engine.resources.limits.cpu }}
+            {{- if $.Values.engine.resources.limits.cpu }}
             cpu: "{{ $.Values.engine.resources.limits.cpu }}"
             {{- end }}
             {{- if gt (int $.Values.engine.resources.limits.gpu) 0 }}
@@ -161,13 +161,13 @@ spec:
           {{- $gcpGpdEnabled := $.Values.engine.modelManager.volumes.gcp.gpd.enabled }}
 
           {{- $enabledCount := (int $customClaimEnabled) | add (int $awsEfsEnabled) | add (int $gcpGpdEnabled) }}
- 
+
           {{- if eq $enabledCount 0 }}
           {{- fail "Error: At least one of customVolumeClaim.enabled, aws.efs.enabled, or gcp.gpd.enabled must be set to true." }}
           {{- else if gt $enabledCount 1 }}
           {{- fail "Error: Only one of customVolumeClaim.enabled, aws.efs.enabled, or gcp.gpd.enabled can be set to true." }}
           {{- end }}
- 
+
           {{- if $customClaimEnabled }}
             {{- if not $customClaimName }}
             {{- fail "Error: customVolumeClaim.name must be set when customVolumeClaim.enabled is true." }}

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -108,7 +108,7 @@ spec:
         resources:
           requests:
             memory: "{{ $.Values.engine.resources.requests.memory }}"
-            cpu: "{{ .Values.engine.resources.requests.cpu }}"
+            cpu: "{{ $.Values.engine.resources.requests.cpu }}"
             {{- if gt (int $.Values.engine.resources.requests.gpu) 0 }}
             nvidia.com/gpu: {{ $.Values.engine.resources.requests.gpu }}
             {{- end }}


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Allow `null` or an empty string to be set for the `engine` CPU and memory limits to avoid setting limits on these containers.

Resolves https://github.com/deepgram/self-hosted-resources/issues/92

## Types of changes

What types of changes does your code introduce to the Deepgram self-hosted resources?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
  - Tested by deploying from local chart, upgrading from a previously deployed chart.
  - Values files updated to set:
 ```
engine:
  resources:
    limits:
      cpu: null
      memory: ""
```
  - `helm diff` output
 ```
          resources:
            requests:
              memory: "20Gi"
              cpu: "6"
              nvidia.com/gpu: 1
            limits:
-             memory: "40Gi"
-             cpu: "8000m"
              nvidia.com/gpu: 1
```
  - 
- [x] I have added necessary documentation (if appropriate)
  -  I ran `helm-docs` locally but there was no change

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
