### PR TITLE
Enable NER-powered STT redaction by default

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Added `topologySpreadConstraints`, which allows even distribution of pods from the same deployment across availability zones, among other criteria
 - Added `redactUsage` under api features which enables redaction of usage metadata
 
+### Changed
+
+- Set `entity_redaction` to `true` by default, so redaction is automatically enabled if a valid NER model is available
+
 ## [0.21.0] - 2025-09-29
 
 ### Changed

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -266,7 +266,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | api.features | object | `` | Enable ancillary features |
 | api.features.diskBufferPath | string | `nil` | If API is receiving requests faster than Engine can process them, a request queue will form. By default, this queue is stored in memory. Under high load, the queue may grow too large and cause Out-Of-Memory errors. To avoid this, set a diskBufferPath to buffer the overflow on the request queue to disk.  WARN: This is only to temporarily buffer requests during high load. If there is not enough Engine capacity to process the queued requests over time, the queue (and response time) will grow indefinitely. |
 | api.features.entityDetection | bool | `false` | Enables entity detection on pre-recorded audio *if* a valid entity detection model is available. |
-| api.features.entityRedaction | bool | `false` | Enables entity-based redaction on pre-recorded audio *if* a valid entity detection model is available. |
+| api.features.entityRedaction | bool | `true` | Enables entity-based redaction on pre-recorded audio *if* a valid entity detection model is available. |
 | api.features.formatEntityTags | bool | `true` | Enables format entity tags on pre-recorded audio *if* a valid NER model is available. |
 | api.features.redactUsage | bool | `true` | Enables usage metadata redaction; set to false to disable redaction of usage metadata |
 | api.image.path | string | `"quay.io/deepgram/self-hosted-api"` | path configures the image path to use for creating API containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -382,7 +382,7 @@ api:
 
     # -- Enables entity-based redaction on pre-recorded audio
     # *if* a valid entity detection model is available.
-    entityRedaction: false
+    entityRedaction: true
 
     # -- Enables format entity tags on pre-recorded audio
     # *if* a valid NER model is available.

--- a/common/license_proxy_deploy/api.toml
+++ b/common/license_proxy_deploy/api.toml
@@ -70,7 +70,7 @@ summarization = true # or false
 entity_detection = false # or true
 
 ### Enables pre-recorded entity-based redaction *if* a valid entity detection model is available
-entity_redaction = false # or true
+entity_redaction = true # or false
 
 ### Enables pre-recorded entity formatting *if* a valid NER model is available
 format_entity_tags = false # or true

--- a/common/standard_deploy/api.toml
+++ b/common/standard_deploy/api.toml
@@ -68,7 +68,7 @@ summarization = true # or false
 entity_detection = false # or true
 
 ### Enables pre-recorded entity-based redaction *if* a valid entity detection model is available
-entity_redaction = false # or true
+entity_redaction = true # or false
 
 ### Enables pre-recorded entity formatting *if* a valid NER model is available
 format_entity_tags = true # or false


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Enable NER-powered STT redaction by default. It was first launched in 240725, so after 14 months, we should support our latest and greatest redaction by default, instead of silently falling back to an inferior redaction implementation. It's better for redaction to fail loudly than be mediocre silently.

## Types of changes

What types of changes does your code introduce to the Deepgram self-hosted resources?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have tested my changes in my local self-hosted environment
  - Please describe your testing setup and methodology here
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
