### PR TITLE
fix: enable batch NER by default in remaining non-TTS api.toml

### DIFF
--- a/common/license_proxy_deploy/api.toml
+++ b/common/license_proxy_deploy/api.toml
@@ -73,7 +73,7 @@ entity_detection = false # or true
 entity_redaction = true # or false
 
 ### Enables pre-recorded entity formatting *if* a valid NER model is available
-format_entity_tags = false # or true
+format_entity_tags = true # or false
 
 ### If API is receiving requests faster than Engine can process them, a request
 ### queue will form. By default, this queue is stored in memory. Under high load,


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

In September 2025, we enabled NER by default in non-TTS TOML files by setting `format_entity_tags` and `streaming_ner` to `true` by default: https://github.com/deepgram/self-hosted-resources/pull/90/changes

This PR fixes one instance that we overlooked previously.

## Types of changes

What types of changes does your code introduce to the Deepgram self-hosted resources?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have tested my changes in my local self-hosted environment
  - Please describe your testing setup and methodology here
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
