### PR TITLE
Self-hosted release 260402: bump default container tags

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -17,6 +17,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Standardized sample values files to fix drift from the reference configuration (missing resource limits, null `features:` overrides, inconsistent global section, incorrect model list format)
 
+## [0.33.0] - 2026-04-02
+
+### Changed
+
+- Updated default container tags to April 2026 release (`release-260402`). Refer to the [main Deepgram changelog](https://developers.deepgram.com/changelog/self-hosted-changelog#deepgram-self-hosted-april-2026-release-260402) for additional details.
+
 ## [0.32.0] - 2026-03-19
 
 ### Added

--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -401,7 +401,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Initial implementation of the Helm chart.
 
-[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.32.0...HEAD
+[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.33.0...HEAD
+[0.33.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.32.0...deepgram-self-hosted-0.33.0
 [0.32.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.31.0...deepgram-self-hosted-0.32.0
 [0.31.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.30.0...deepgram-self-hosted-0.31.0
 [0.30.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.29.1...deepgram-self-hosted-0.30.0

--- a/charts/deepgram-self-hosted/Chart.yaml
+++ b/charts/deepgram-self-hosted/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: deepgram-self-hosted
 type: application
-version: 0.32.0
+version: 0.33.0
 appVersion: "release-260402"
 description: A Helm chart for running Deepgram services in a self-hosted environment
 home: "https://developers.deepgram.com/docs/self-hosted-introduction"

--- a/charts/deepgram-self-hosted/Chart.yaml
+++ b/charts/deepgram-self-hosted/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: deepgram-self-hosted
 type: application
 version: 0.32.0
-appVersion: "release-260319"
+appVersion: "release-260402"
 description: A Helm chart for running Deepgram services in a self-hosted environment
 home: "https://developers.deepgram.com/docs/self-hosted-introduction"
 sources: ["https://github.com/deepgram/self-hosted-resources"]

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -1,6 +1,6 @@
 # deepgram-self-hosted
 
-![Version: 0.32.0](https://img.shields.io/badge/Version-0.32.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260402](https://img.shields.io/badge/AppVersion-release--260402-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
+![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260402](https://img.shields.io/badge/AppVersion-release--260402-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
 
 A Helm chart for running Deepgram services in a self-hosted environment
 

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -1,6 +1,6 @@
 # deepgram-self-hosted
 
-![Version: 0.32.0](https://img.shields.io/badge/Version-0.32.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260319](https://img.shields.io/badge/AppVersion-release--260319-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
+![Version: 0.32.0](https://img.shields.io/badge/Version-0.32.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260402](https://img.shields.io/badge/AppVersion-release--260402-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
 
 A Helm chart for running Deepgram services in a self-hosted environment
 
@@ -281,7 +281,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | api.features.redactUsage | bool | `true` | Enables usage metadata redaction; set to false to disable redaction of usage metadata |
 | api.image.path | string | `"quay.io/deepgram/self-hosted-api"` | path configures the image path to use for creating API containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | api.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram API image |
-| api.image.tag | string | `"release-260319"` | tag defines which Deepgram release to use for API containers |
+| api.image.tag | string | `"release-260402"` | tag defines which Deepgram release to use for API containers |
 | api.livenessProbe | object | `` | Liveness probe customization for API pods. |
 | api.namePrefix | string | `"deepgram-api"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram API containers. |
 | api.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to API pods. |
@@ -323,7 +323,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | billing.extraEnv | list | `[]` | Extra environment variables for the Billing container. |
 | billing.image.path | string | `"quay.io/deepgram/self-hosted-billing"` | path configures the image path to use for creating Billing containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | billing.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram Billing image |
-| billing.image.tag | string | `"release-260319"` | tag defines which Deepgram release to use for Billing containers |
+| billing.image.tag | string | `"release-260402"` | tag defines which Deepgram release to use for Billing containers |
 | billing.journal | object | `` | Configuration for the usage journal volume. The journal tracks usage for billing purposes and must be persisted. WARNING: Do not delete or lose this volume as it contains critical billing data. Failure to persist and return journal files may result in suspension of service. |
 | billing.journal.aws | object | `` | AWS-specific volume configuration for billing journals |
 | billing.journal.aws.efs.size | string | `"1Gi"` | Size of the EFS PVC for journals. |
@@ -378,7 +378,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | engine.health.gpuRequired | bool | `false` | Engine will automatically fall back to CPU when a GPU is not detected. You can explicitly require a GPU by setting this option to true, production deployments must use a GPU for acceptable performance. |
 | engine.image.path | string | `"quay.io/deepgram/self-hosted-engine"` | path configures the image path to use for creating Engine containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | engine.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram Engine image |
-| engine.image.tag | string | `"release-260319"` | tag defines which Deepgram release to use for Engine containers |
+| engine.image.tag | string | `"release-260402"` | tag defines which Deepgram release to use for Engine containers |
 | engine.lifecycle | object | `` | Configuration for container lifecycle hooks |
 | engine.lifecycle.postStart.command | list | `[]` | Command to execute in a postStart hook. Leave empty to disable. Example: ["/sbin/ldconfig"] |
 | engine.livenessProbe | object | `` | Liveness probe customization for Engine pods. |
@@ -459,7 +459,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | licenseProxy.extraEnv | list | `[]` | Extra environment variables for the License Proxy container. |
 | licenseProxy.image.path | string | `"quay.io/deepgram/self-hosted-license-proxy"` | path configures the image path to use for creating License Proxy containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | licenseProxy.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram License Proxy image |
-| licenseProxy.image.tag | string | `"release-260319"` | tag defines which Deepgram release to use for License Proxy containers |
+| licenseProxy.image.tag | string | `"release-260402"` | tag defines which Deepgram release to use for License Proxy containers |
 | licenseProxy.keepUpstreamServerAsBackup | bool | `true` | Even with a License Proxy deployed, API and Engine pods can be configured to keep the upstream `license.deepgram.com` license server as a fallback licensing option if the License Proxy is unavailable. Disable this option if you are restricting API/Engine Pod network access for security reasons, and only the License Proxy should send egress traffic to the upstream license server. |
 | licenseProxy.livenessProbe | object | `` | Liveness probe customization for Proxy pods. |
 | licenseProxy.namePrefix | string | `"deepgram-license-proxy"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram License Proxy containers. |

--- a/charts/deepgram-self-hosted/samples/04-aura-2-setup.values.yaml
+++ b/charts/deepgram-self-hosted/samples/04-aura-2-setup.values.yaml
@@ -42,7 +42,7 @@ scaling:
 # API configuration for English Aura-2
 api:
   image:
-    tag: release-260319
+    tag: release-260402
   
   # Configure driver pool to connect to both language engines
   driverPool:
@@ -55,7 +55,7 @@ api:
 # Engine configuration for Aura-2
 engine:
   image:
-    tag: release-260319
+    tag: release-260402
   
   # Aura-2 requires more resources than standard models
   resources:
@@ -113,7 +113,7 @@ licenseProxy:
   keepUpstreamServerAsBackup: true
   
   image:
-    tag: release-260319
+    tag: release-260402
 
 # Monitoring configuration for Aura-2
 # Enable Prometheus stack for metrics collection

--- a/charts/deepgram-self-hosted/samples/06-aura-2-polyglot-setup.values.yaml
+++ b/charts/deepgram-self-hosted/samples/06-aura-2-polyglot-setup.values.yaml
@@ -42,7 +42,7 @@ scaling:
 # API configuration for English and Polyglot Aura-2
 api:
   image:
-    tag: release-260319
+    tag: release-260402
 
   # Configure driver pool to connect to both language engines
   driverPool:
@@ -55,7 +55,7 @@ api:
 # Engine configuration for Aura-2
 engine:
   image:
-    tag: release-260319
+    tag: release-260402
 
   # Aura-2 requires more resources than standard models
   resources:
@@ -113,7 +113,7 @@ licenseProxy:
   keepUpstreamServerAsBackup: true
 
   image:
-    tag: release-260319
+    tag: release-260402
 
 # Monitoring configuration for Aura-2
 # Enable Prometheus stack for metrics collection

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -253,7 +253,7 @@ api:
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram API image
     pullPolicy: IfNotPresent
     # -- tag defines which Deepgram release to use for API containers
-    tag: release-260319
+    tag: release-260402
 
   # -- Additional labels to add to API resources
   additionalLabels: {}
@@ -474,7 +474,7 @@ engine:
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram Engine image
     pullPolicy: IfNotPresent
     # -- tag defines which Deepgram release to use for Engine containers
-    tag: release-260319
+    tag: release-260402
 
   # -- Additional labels to add to Engine resources
   additionalLabels: {}
@@ -820,7 +820,7 @@ licenseProxy:
     # Deepgram images into a private container registry.
     path: quay.io/deepgram/self-hosted-license-proxy
     # -- tag defines which Deepgram release to use for License Proxy containers
-    tag: release-260319
+    tag: release-260402
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram
     # License Proxy image
     pullPolicy: IfNotPresent
@@ -973,7 +973,7 @@ billing:
     # Deepgram images into a private container registry.
     path: quay.io/deepgram/self-hosted-billing
     # -- tag defines which Deepgram release to use for Billing containers
-    tag: release-260319
+    tag: release-260402
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram
     # Billing image
     pullPolicy: IfNotPresent

--- a/docker/docker-compose.aura-2-polyglot.yml
+++ b/docker/docker-compose.aura-2-polyglot.yml
@@ -10,7 +10,7 @@ services:
   # The speech API service.
   # English Language Aura-2
   api-en:
-    image: quay.io/deepgram/self-hosted-api:release-260319
+    image: quay.io/deepgram/self-hosted-api:release-260402
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -37,7 +37,7 @@ services:
 
   # Polyglot Aura-2 (Dutch, German, French, Italian, Japanese)
   api-polyglot:
-    image: quay.io/deepgram/self-hosted-api:release-260319
+    image: quay.io/deepgram/self-hosted-api:release-260402
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -65,7 +65,7 @@ services:
   # The speech engine service.
   # English Language Aura-2 Driver
   engine-en:
-    image: quay.io/deepgram/self-hosted-engine:release-260319
+    image: quay.io/deepgram/self-hosted-engine:release-260402
     restart: always
 
     # Utilize a GPU, if available.
@@ -98,7 +98,7 @@ services:
 
   # Polyglot (Dutch, German, French, Italian, Japanese) Aura-2 Driver
   engine-polyglot:
-    image: quay.io/deepgram/self-hosted-engine:release-260319
+    image: quay.io/deepgram/self-hosted-engine:release-260402
     restart: always
 
     # Utilize a GPU, if available.
@@ -131,7 +131,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260319
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260402
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/docker/docker-compose.aura-2.yml
+++ b/docker/docker-compose.aura-2.yml
@@ -10,7 +10,7 @@ services:
   # The speech API service.
   # English Language Aura-2
   api-en:
-    image: quay.io/deepgram/self-hosted-api:release-260319
+    image: quay.io/deepgram/self-hosted-api:release-260402
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -37,7 +37,7 @@ services:
 
   # Spanish Language Aura-2
   api-es:
-    image: quay.io/deepgram/self-hosted-api:release-260319
+    image: quay.io/deepgram/self-hosted-api:release-260402
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -65,7 +65,7 @@ services:
   # The speech engine service.
   # English Language Aura-2 Driver
   engine-en:
-    image: quay.io/deepgram/self-hosted-engine:release-260319
+    image: quay.io/deepgram/self-hosted-engine:release-260402
     restart: always
 
     # Utilize a GPU, if available.
@@ -98,7 +98,7 @@ services:
 
   # Spanish Language Aura-2 Driver
   engine-es:
-    image: quay.io/deepgram/self-hosted-engine:release-260319
+    image: quay.io/deepgram/self-hosted-engine:release-260402
     restart: always
 
     # Utilize a GPU, if available.
@@ -131,7 +131,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260319
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260402
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/docker/docker-compose.license-proxy.yml
+++ b/docker/docker-compose.license-proxy.yml
@@ -9,7 +9,7 @@ x-env: &env
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-260319
+    image: quay.io/deepgram/self-hosted-api:release-260402
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -35,7 +35,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-260319
+    image: quay.io/deepgram/self-hosted-engine:release-260402
     restart: always
 
     # Utilize a GPU, if available.
@@ -63,7 +63,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260319
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260402
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/docker/docker-compose.standard.yml
+++ b/docker/docker-compose.standard.yml
@@ -9,7 +9,7 @@ x-env: &env
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-260319
+    image: quay.io/deepgram/self-hosted-api:release-260402
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -31,7 +31,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-260319
+    image: quay.io/deepgram/self-hosted-engine:release-260402
     restart: always
 
     # Utilize a GPU, if available.

--- a/podman/podman-compose.aura-2.yml
+++ b/podman/podman-compose.aura-2.yml
@@ -4,7 +4,7 @@ services:
   # The speech API service.
   # English Language Aura-2
   api-en:
-    image: quay.io/deepgram/self-hosted-api:release-260319
+    image: quay.io/deepgram/self-hosted-api:release-260402
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -33,7 +33,7 @@ services:
 
   # Spanish Language Aura-2
   api-es:
-    image: quay.io/deepgram/self-hosted-api:release-260319
+    image: quay.io/deepgram/self-hosted-api:release-260402
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -63,7 +63,7 @@ services:
   # The speech engine service.
   # English Language Aura-2 Driver
   engine-en:
-    image: quay.io/deepgram/self-hosted-engine:release-260319
+    image: quay.io/deepgram/self-hosted-engine:release-260402
     restart: always
 
     # Utilize a GPU, if available.
@@ -99,7 +99,7 @@ services:
 
   # Spanish Language Aura-2 Driver
   engine-es:
-    image: quay.io/deepgram/self-hosted-engine:release-260319
+    image: quay.io/deepgram/self-hosted-engine:release-260402
     restart: always
 
     # Utilize a GPU, if available.
@@ -135,7 +135,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260319
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260402
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/podman/podman-compose.license-proxy.yml
+++ b/podman/podman-compose.license-proxy.yml
@@ -3,7 +3,7 @@
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-260319
+    image: quay.io/deepgram/self-hosted-api:release-260402
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -32,7 +32,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-260319
+    image: quay.io/deepgram/self-hosted-engine:release-260402
     restart: always
 
     # Utilize a GPU, if available.
@@ -64,7 +64,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260319
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260402
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/podman/podman-compose.standard.yml
+++ b/podman/podman-compose.standard.yml
@@ -3,7 +3,7 @@
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-260319
+    image: quay.io/deepgram/self-hosted-api:release-260402
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -28,7 +28,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-260319
+    image: quay.io/deepgram/self-hosted-engine:release-260402
     restart: always
 
     # Utilize a GPU, if available.


### PR DESCRIPTION
## Summary
- Bumps default container image tags to `release-260402` (API 1.181.3, Engine 3.114.5, License Proxy 1.10.1, Billing 1.13.0)
- Adds CHANGELOG entry for chart version 0.33.0

## Test plan
- [ ] Validated all four self-hosted test endpoints on `release-260402` public tags
- [ ] E2E tests passed for Nova STT (batch + streaming v1) and Flux STT (streaming v2)
- [ ] `/v1/certificates` confirmed on Engine across all endpoints
- [ ] `/v1/models` returning `canonical_name` on Nova STT and Airgap STT