### PR TITLE
Self-hosted release 260416: Flux Multi config + tag bump

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,12 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## [0.34.0] - 2026-04-16
+
 ### Added
 
+- Added Flux STT configuration variants for English (`engine.flux-en.toml`) and Multilingual (`engine.flux-multi.toml`), plus a shared `api.flux.toml`
+  - Flux Multilingual requires `model_name = "flux-general-multi"` in the `[flux]` section of `engine.toml`. Without this, Engine defaults to loading the English model.
 - Added `engine.runtimeClassName` value to configure a Kubernetes RuntimeClass on Engine pods
 - Added a 15-minute Time-to-Live (TTL) to the model download pod, configurable via `ttlSecondsAfterFinished`
   - This helps to fix an issue where a lock is held on the PersistentVolume resource, when attempting to delete the Deepgram Kubernetes namespace
 - Added `engine.resources.gpuResourceName` to make the GPU resource name configurable for MIG support
+
+### Changed
+
+- Updated default container tags to April 2026 release (`release-260416`). Refer to the [main Deepgram changelog](https://developers.deepgram.com/changelog/self-hosted-changelog#deepgram-self-hosted-april-2026-release-260416) for additional details.
+- Added commented-out `model_name` option to base `engine.toml` files under the `[flux]` section
 
 ### Fixed
 
@@ -401,7 +410,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Initial implementation of the Helm chart.
 
-[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.33.0...HEAD
+[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.34.0...HEAD
+[0.34.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.33.0...deepgram-self-hosted-0.34.0
 [0.33.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.32.0...deepgram-self-hosted-0.33.0
 [0.32.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.31.0...deepgram-self-hosted-0.32.0
 [0.31.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.30.0...deepgram-self-hosted-0.31.0

--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Added Flux STT configuration variants for English (`engine.flux-en.toml`) and Multilingual (`engine.flux-multi.toml`), plus a shared `api.flux.toml`
-  - Flux Multilingual requires `model_name = "flux-general-multi"` in the `[flux]` section of `engine.toml`. Without this, Engine defaults to loading the English model.
+  - `engine.flux-multi.toml` sets `model_name = "flux-general-multi"` explicitly to load Multilingual Flux instead of English Flux.
 - Added `engine.flux.model_name` value to select which Flux model to load. Defaults to `flux-general-en`; set to `flux-general-multi` for the Multilingual model.
 - Added `engine.runtimeClassName` value to configure a Kubernetes RuntimeClass on Engine pods
 - Added a 15-minute Time-to-Live (TTL) to the model download pod, configurable via `ttlSecondsAfterFinished`
@@ -21,7 +21,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Updated default container tags to April 2026 release (`release-260416`). Refer to the [main Deepgram changelog](https://developers.deepgram.com/changelog/self-hosted-changelog#deepgram-self-hosted-april-2026-release-260416) for additional details.
-- Added commented-out `model_name` option to base `engine.toml` files under the `[flux]` section
 
 ### Fixed
 

--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Added Flux STT configuration variants for English (`engine.flux-en.toml`) and Multilingual (`engine.flux-multi.toml`), plus a shared `api.flux.toml`
   - Flux Multilingual requires `model_name = "flux-general-multi"` in the `[flux]` section of `engine.toml`. Without this, Engine defaults to loading the English model.
+- Added `engine.flux.model_name` value to select which Flux model to load. Defaults to `flux-general-en`; set to `flux-general-multi` for the Multilingual model.
 - Added `engine.runtimeClassName` value to configure a Kubernetes RuntimeClass on Engine pods
 - Added a 15-minute Time-to-Live (TTL) to the model download pod, configurable via `ttlSecondsAfterFinished`
   - This helps to fix an issue where a lock is held on the PersistentVolume resource, when attempting to delete the Deepgram Kubernetes namespace

--- a/charts/deepgram-self-hosted/Chart.yaml
+++ b/charts/deepgram-self-hosted/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: deepgram-self-hosted
 type: application
-version: 0.33.0
-appVersion: "release-260402"
+version: 0.34.0
+appVersion: "release-260416"
 description: A Helm chart for running Deepgram services in a self-hosted environment
 home: "https://developers.deepgram.com/docs/self-hosted-introduction"
 sources: ["https://github.com/deepgram/self-hosted-resources"]

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -1,6 +1,6 @@
 # deepgram-self-hosted
 
-![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260402](https://img.shields.io/badge/AppVersion-release--260402-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
+![Version: 0.34.0](https://img.shields.io/badge/Version-0.34.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260416](https://img.shields.io/badge/AppVersion-release--260416-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
 
 A Helm chart for running Deepgram services in a self-hosted environment
 
@@ -281,7 +281,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | api.features.redactUsage | bool | `true` | Enables usage metadata redaction; set to false to disable redaction of usage metadata |
 | api.image.path | string | `"quay.io/deepgram/self-hosted-api"` | path configures the image path to use for creating API containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | api.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram API image |
-| api.image.tag | string | `"release-260402"` | tag defines which Deepgram release to use for API containers |
+| api.image.tag | string | `"release-260416"` | tag defines which Deepgram release to use for API containers |
 | api.livenessProbe | object | `` | Liveness probe customization for API pods. |
 | api.namePrefix | string | `"deepgram-api"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram API containers. |
 | api.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to API pods. |
@@ -323,7 +323,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | billing.extraEnv | list | `[]` | Extra environment variables for the Billing container. |
 | billing.image.path | string | `"quay.io/deepgram/self-hosted-billing"` | path configures the image path to use for creating Billing containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | billing.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram Billing image |
-| billing.image.tag | string | `"release-260402"` | tag defines which Deepgram release to use for Billing containers |
+| billing.image.tag | string | `"release-260416"` | tag defines which Deepgram release to use for Billing containers |
 | billing.journal | object | `` | Configuration for the usage journal volume. The journal tracks usage for billing purposes and must be persisted. WARNING: Do not delete or lose this volume as it contains critical billing data. Failure to persist and return journal files may result in suspension of service. |
 | billing.journal.aws | object | `` | AWS-specific volume configuration for billing journals |
 | billing.journal.aws.efs.size | string | `"1Gi"` | Size of the EFS PVC for journals. |
@@ -378,7 +378,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | engine.health.gpuRequired | bool | `false` | Engine will automatically fall back to CPU when a GPU is not detected. You can explicitly require a GPU by setting this option to true, production deployments must use a GPU for acceptable performance. |
 | engine.image.path | string | `"quay.io/deepgram/self-hosted-engine"` | path configures the image path to use for creating Engine containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | engine.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram Engine image |
-| engine.image.tag | string | `"release-260402"` | tag defines which Deepgram release to use for Engine containers |
+| engine.image.tag | string | `"release-260416"` | tag defines which Deepgram release to use for Engine containers |
 | engine.lifecycle | object | `` | Configuration for container lifecycle hooks |
 | engine.lifecycle.postStart.command | list | `[]` | Command to execute in a postStart hook. Leave empty to disable. Example: ["/sbin/ldconfig"] |
 | engine.livenessProbe | object | `` | Liveness probe customization for Engine pods. |
@@ -459,7 +459,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | licenseProxy.extraEnv | list | `[]` | Extra environment variables for the License Proxy container. |
 | licenseProxy.image.path | string | `"quay.io/deepgram/self-hosted-license-proxy"` | path configures the image path to use for creating License Proxy containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | licenseProxy.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram License Proxy image |
-| licenseProxy.image.tag | string | `"release-260402"` | tag defines which Deepgram release to use for License Proxy containers |
+| licenseProxy.image.tag | string | `"release-260416"` | tag defines which Deepgram release to use for License Proxy containers |
 | licenseProxy.keepUpstreamServerAsBackup | bool | `true` | Even with a License Proxy deployed, API and Engine pods can be configured to keep the upstream `license.deepgram.com` license server as a fallback licensing option if the License Proxy is unavailable. Disable this option if you are restricting API/Engine Pod network access for security reasons, and only the License Proxy should send egress traffic to the upstream license server. |
 | licenseProxy.livenessProbe | object | `` | Liveness probe customization for Proxy pods. |
 | licenseProxy.namePrefix | string | `"deepgram-license-proxy"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram License Proxy containers. |

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -374,6 +374,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | engine.features.useV2LanguageDetection | bool | `false` | Enables use of 36-language detection model. |
 | engine.flux.enabled | bool | `false` | Enables Flux turn-based streaming STT |
 | engine.flux.max_streams | string | `nil` | Specify the maximum number of streams for the Flux model in the Engine process. This must be set for production workloads based on the GPU type used in the deployment. |
+| engine.flux.model_name | string | `"flux-general-en"` | Specify which Flux model to load. Options: `flux-general-en` (default), `flux-general-multi`. |
 | engine.halfPrecision.state | string | `"auto"` | Engine will automatically enable half precision operations if your GPU supports them. You can explicitly enable or disable this behavior with the state parameter which supports `"enable"`, `"disabled"`, and `"auto"`. |
 | engine.health.gpuRequired | bool | `false` | Engine will automatically fall back to CPU when a GPU is not detected. You can explicitly require a GPU by setting this option to true, production deployments must use a GPU for acceptable performance. |
 | engine.image.path | string | `"quay.io/deepgram/self-hosted-engine"` | path configures the image path to use for creating Engine containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |

--- a/charts/deepgram-self-hosted/samples/04-aura-2-setup.values.yaml
+++ b/charts/deepgram-self-hosted/samples/04-aura-2-setup.values.yaml
@@ -42,7 +42,7 @@ scaling:
 # API configuration for English Aura-2
 api:
   image:
-    tag: release-260402
+    tag: release-260416
   
   # Configure driver pool to connect to both language engines
   driverPool:
@@ -55,7 +55,7 @@ api:
 # Engine configuration for Aura-2
 engine:
   image:
-    tag: release-260402
+    tag: release-260416
   
   # Aura-2 requires more resources than standard models
   resources:
@@ -113,7 +113,7 @@ licenseProxy:
   keepUpstreamServerAsBackup: true
   
   image:
-    tag: release-260402
+    tag: release-260416
 
 # Monitoring configuration for Aura-2
 # Enable Prometheus stack for metrics collection

--- a/charts/deepgram-self-hosted/samples/06-aura-2-polyglot-setup.values.yaml
+++ b/charts/deepgram-self-hosted/samples/06-aura-2-polyglot-setup.values.yaml
@@ -42,7 +42,7 @@ scaling:
 # API configuration for English and Polyglot Aura-2
 api:
   image:
-    tag: release-260402
+    tag: release-260416
 
   # Configure driver pool to connect to both language engines
   driverPool:
@@ -55,7 +55,7 @@ api:
 # Engine configuration for Aura-2
 engine:
   image:
-    tag: release-260402
+    tag: release-260416
 
   # Aura-2 requires more resources than standard models
   resources:
@@ -113,7 +113,7 @@ licenseProxy:
   keepUpstreamServerAsBackup: true
 
   image:
-    tag: release-260402
+    tag: release-260416
 
 # Monitoring configuration for Aura-2
 # Enable Prometheus stack for metrics collection

--- a/charts/deepgram-self-hosted/templates/engine/engine.config.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.config.yaml
@@ -58,6 +58,7 @@ data:
       {{- if .Values.engine.flux.max_streams }}
       max_streams = {{ .Values.engine.flux.max_streams }}
       {{- end }}
+      model_name = "{{ .Values.engine.flux.model_name }}"
 
     [chunking.batch]
       {{- if .Values.engine.chunking.speechToText.batch.minDuration }}

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -253,7 +253,7 @@ api:
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram API image
     pullPolicy: IfNotPresent
     # -- tag defines which Deepgram release to use for API containers
-    tag: release-260402
+    tag: release-260416
 
   # -- Additional labels to add to API resources
   additionalLabels: {}
@@ -474,7 +474,7 @@ engine:
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram Engine image
     pullPolicy: IfNotPresent
     # -- tag defines which Deepgram release to use for Engine containers
-    tag: release-260402
+    tag: release-260416
 
   # -- Additional labels to add to Engine resources
   additionalLabels: {}
@@ -820,7 +820,7 @@ licenseProxy:
     # Deepgram images into a private container registry.
     path: quay.io/deepgram/self-hosted-license-proxy
     # -- tag defines which Deepgram release to use for License Proxy containers
-    tag: release-260402
+    tag: release-260416
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram
     # License Proxy image
     pullPolicy: IfNotPresent
@@ -973,7 +973,7 @@ billing:
     # Deepgram images into a private container registry.
     path: quay.io/deepgram/self-hosted-billing
     # -- tag defines which Deepgram release to use for Billing containers
-    tag: release-260402
+    tag: release-260416
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram
     # Billing image
     pullPolicy: IfNotPresent

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -746,6 +746,8 @@ engine:
     enabled: false
     # -- Specify the maximum number of streams for the Flux model in the Engine process. This must be set for production workloads based on the GPU type used in the deployment.
     max_streams:
+    # -- Specify which Flux model to load. Options: `flux-general-en` (default), `flux-general-multi`.
+    model_name: flux-general-en
 
   # -- chunking defines the size of audio chunks to process in seconds.
   # Adjusting these values will affect both inference performance and accuracy

--- a/common/license_proxy_deploy/api.aura-2-en.toml
+++ b/common/license_proxy_deploy/api.aura-2-en.toml
@@ -92,7 +92,7 @@ speak_streaming = true # or false
 # redact_usage = true # or false
 
 ### Enables Flux turn-based streaming STT
-listen_v2 = false # or true
+listen_v2 = false
 
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard

--- a/common/license_proxy_deploy/api.aura-2-es.toml
+++ b/common/license_proxy_deploy/api.aura-2-es.toml
@@ -92,7 +92,7 @@ speak_streaming = true # or false
 # redact_usage = true # or false
 
 ### Enables Flux turn-based streaming STT
-listen_v2 = false # or true
+listen_v2 = false
 
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard

--- a/common/license_proxy_deploy/api.aura-2-polyglot.toml
+++ b/common/license_proxy_deploy/api.aura-2-polyglot.toml
@@ -92,7 +92,7 @@ speak_streaming = true # or false
 # redact_usage = true # or false
 
 ### Enables Flux turn-based streaming STT
-listen_v2 = false # or true
+listen_v2 = false
 
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard

--- a/common/license_proxy_deploy/api.flux.toml
+++ b/common/license_proxy_deploy/api.flux.toml
@@ -1,0 +1,129 @@
+### Keep in mind that all paths are in-container paths, and do not need to exist
+### on the host machine.
+
+
+### Configure license validation by passing in a DEEPGRAM_API_KEY environment variable
+### See https://developers.deepgram.com/docs/deploy-deepgram-services#credentials
+[license]
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+server_url = ["https://license-proxy:8443", "https://license.deepgram.com"]
+
+
+### Configure how the API will listen for your requests
+[server]
+### The base URL (prefix) for requests to the API.
+base_url = "/v1"
+### The IP address to listen on. Since this is likely running in a Docker
+### container, you will probably want to listen on all interfaces.
+host = "0.0.0.0"
+### The port to listen on
+port = 8080
+
+### How long to wait for a connection to a callback URL.
+callback_conn_timeout = "1s"
+### How long to wait for a response to a callback URL.
+callback_timeout = "10s"
+
+### How long to wait for a connection to a fetch URL.
+fetch_conn_timeout = "1s"
+### How long to wait for a response to a fetch URL.
+fetch_timeout = "60s"
+
+
+### By default, the API listens over HTTP. By passing both a certificate
+### and a key file, the API will instead listen over HTTPS.
+###
+### This performs TLS termination only, and does not provide any
+### additional authentication.
+[server.https]
+# cert_file = "/path/to/cert.pem"
+# key_file = "/path/to/key.pem"
+
+
+### Specify custom DNS resolution options.
+[resolver]
+### Specify custom domain name server(s).
+### Format is "{IP} {PORT} {PROTOCOL (tcp or udp)}"
+# nameservers = ["127.0.0.1 53 udp"]
+
+### If specifying a custom DNS nameserver, set the DNS TTL value.
+# max_ttl = 10
+
+
+### Limit the number of active requests handled by a single API container.
+### If additional requests beyond the limit are sent, API will return
+### a 429 HTTP status code. Default is no limit.
+[concurrency_limit]
+# active_requests =
+
+
+### Enable ancillary features
+[features]
+### Enables topic detection *if* a valid topic detection model is available
+topic_detection = true # or false
+
+### Enables summarization *if* a valid summarization model is available
+summarization = true # or false
+
+### Enables pre-recorded entity detection *if* a valid entity detection model is available
+entity_detection = false # or true
+
+### Enables pre-recorded entity-based redaction *if* a valid entity detection model is available
+entity_redaction = true # or false
+
+### Enables pre-recorded entity formatting *if* a valid NER model is available
+format_entity_tags = true # or false
+
+### If API is receiving requests faster than Engine can process them, a request
+### queue will form. By default, this queue is stored in memory. Under high load,
+### the queue may grow too large and cause Out-Of-Memory errors. To avoid this,
+### set a disk_buffer_path to buffer the overflow on the request queue to disk.
+###
+### WARN: This is only to temporarily buffer requests during high load.
+### If there is not enough Engine capacity to process the queued requests over time,
+### the queue (and response time) will grow indefinitely.
+# disk_buffer_path = "/path/to/disk/buffer/directory"
+
+### Enables streaming TTS *if* a valid Aura TTS model is available
+speak_streaming = true # or false
+
+### Toggles usage data redaction; set to false to disable redaction of usage data; defaults to true if not present
+# redact_usage = true # or false
+
+### Enables Flux turn-based streaming STT
+listen_v2 = true
+
+### Configure the backend pool of speech engines (generically referred to as
+### "drivers" here). The API will load-balance among drivers in the standard
+### pool; if one standard driver fails, the next one will be tried.
+###
+### Each driver URL will have its hostname resolved to an IP address. If a domain
+### name resolves to multiple IP addresses, the API will load-balance across each
+### IP address.
+###
+### This behavior is provided for convenience, and in a production environment
+### other tools can be used, such as HAProxy.
+###
+### Below is a new Speech Engine ("driver") in the "standard" pool.
+[[driver_pool.standard]]
+### Host to connect to. If you are using a different method of orchestrating,
+### then adjust the IP address accordingly.
+###
+### WARN: This must be HTTPS.
+###
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+url = "https://engine:8080/v2"
+### Factor to increase the timeout by for each additional retry (for
+### exponential backoff).
+timeout_backoff = 1.2
+
+### Before attempting a retry, sleep for this long (in seconds)
+retry_sleep = "2s"
+### Factor to increase the retry sleep by for each additional retry (for
+### exponential backoff).
+retry_backoff = 1.6
+
+### Maximum response to deserialize from Driver (in bytes)
+max_response_size = 1073741824 # 1GB

--- a/common/license_proxy_deploy/api.toml
+++ b/common/license_proxy_deploy/api.toml
@@ -92,7 +92,7 @@ speak_streaming = true # or false
 # redact_usage = true # or false
 
 ### Enables Flux turn-based streaming STT
-listen_v2 = false # or true
+listen_v2 = false
 
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard

--- a/common/license_proxy_deploy/engine.aura-2-en.toml
+++ b/common/license_proxy_deploy/engine.aura-2-en.toml
@@ -57,7 +57,7 @@ streaming_ner = true # or false
 
 ### Enable Flux turn-based streaming STT
 [flux]
-enabled = false # or true
+enabled = false
 
 ### Size of audio chunks to process in seconds.
 [chunking.batch]

--- a/common/license_proxy_deploy/engine.aura-2-es.toml
+++ b/common/license_proxy_deploy/engine.aura-2-es.toml
@@ -57,7 +57,7 @@ streaming_ner = true # or false
 
 ### Enable Flux turn-based streaming STT
 [flux]
-enabled = false # or true
+enabled = false
 
 ### Size of audio chunks to process in seconds.
 [chunking.batch]

--- a/common/license_proxy_deploy/engine.aura-2-polyglot.toml
+++ b/common/license_proxy_deploy/engine.aura-2-polyglot.toml
@@ -57,7 +57,7 @@ streaming_ner = true # or false
 
 ### Enable Flux turn-based streaming STT
 [flux]
-enabled = false # or true
+enabled = false
 
 ### Size of audio chunks to process in seconds.
 [chunking.batch]

--- a/common/license_proxy_deploy/engine.flux-en.toml
+++ b/common/license_proxy_deploy/engine.flux-en.toml
@@ -59,9 +59,8 @@ streaming_ner = true # or false
 [flux]
 enabled = true
 ### Specify the maximum number of concurrent streams to the Flux model in the Engine process
-max_streams = 10
-### Specify which Flux model to load. Options: "flux-general-en", "flux-general-multi"
-### If not present, defaults to "flux-general-en".
+# max_streams = 0 # Placeholder; required for production. Set explicitly based on GPU type.
+### Specify which Flux model to load. Options: "flux-general-en" (default), "flux-general-multi"
 model_name = "flux-general-en"
 
 ### Size of audio chunks to process in seconds.

--- a/common/license_proxy_deploy/engine.flux-en.toml
+++ b/common/license_proxy_deploy/engine.flux-en.toml
@@ -12,7 +12,9 @@
 ### Configure license validation by passing in a DEEPGRAM_API_KEY environment variable
 ### See https://developers.deepgram.com/docs/deploy-deepgram-services#credentials
 [license]
-server_url = ["https://license.deepgram.com"]
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+server_url = ["https://license-proxy:8443", "https://license.deepgram.com"]
 
 
 ### Configure the server to listen for requests from the API.
@@ -52,17 +54,15 @@ multichannel = true # or false
 language_detection = true # or false
 ### Enables streaming entity formatting *if* a valid NER model is available
 streaming_ner = true # or false
-### Enables use of 36-language detection model
-use_v2_language_detection = false
 
 ### Enable Flux turn-based streaming STT
 [flux]
-enabled = false # or true
+enabled = true
 ### Specify the maximum number of concurrent streams to the Flux model in the Engine process
-# max_streams = 0 # Placeholder; required for production. Set explicitly based on GPU type.
+max_streams = 10
 ### Specify which Flux model to load. Options: "flux-general-en", "flux-general-multi"
 ### If not present, defaults to "flux-general-en".
-# model_name = "flux-general-en"
+model_name = "flux-general-en"
 
 ### Size of audio chunks to process in seconds.
 [chunking.batch]

--- a/common/license_proxy_deploy/engine.flux-multi.toml
+++ b/common/license_proxy_deploy/engine.flux-multi.toml
@@ -59,9 +59,8 @@ streaming_ner = true # or false
 [flux]
 enabled = true
 ### Specify the maximum number of concurrent streams to the Flux model in the Engine process
-max_streams = 10
-### Specify which Flux model to load. Options: "flux-general-en", "flux-general-multi"
-### If not present, defaults to "flux-general-en".
+# max_streams = 0 # Placeholder; required for production. Set explicitly based on GPU type.
+### Specify which Flux model to load. Options: "flux-general-en" (default), "flux-general-multi"
 model_name = "flux-general-multi"
 
 ### Size of audio chunks to process in seconds.

--- a/common/license_proxy_deploy/engine.flux-multi.toml
+++ b/common/license_proxy_deploy/engine.flux-multi.toml
@@ -12,7 +12,9 @@
 ### Configure license validation by passing in a DEEPGRAM_API_KEY environment variable
 ### See https://developers.deepgram.com/docs/deploy-deepgram-services#credentials
 [license]
-server_url = ["https://license.deepgram.com"]
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+server_url = ["https://license-proxy:8443", "https://license.deepgram.com"]
 
 
 ### Configure the server to listen for requests from the API.
@@ -52,17 +54,15 @@ multichannel = true # or false
 language_detection = true # or false
 ### Enables streaming entity formatting *if* a valid NER model is available
 streaming_ner = true # or false
-### Enables use of 36-language detection model
-use_v2_language_detection = false
 
 ### Enable Flux turn-based streaming STT
 [flux]
-enabled = false # or true
+enabled = true
 ### Specify the maximum number of concurrent streams to the Flux model in the Engine process
-# max_streams = 0 # Placeholder; required for production. Set explicitly based on GPU type.
+max_streams = 10
 ### Specify which Flux model to load. Options: "flux-general-en", "flux-general-multi"
 ### If not present, defaults to "flux-general-en".
-# model_name = "flux-general-en"
+model_name = "flux-general-multi"
 
 ### Size of audio chunks to process in seconds.
 [chunking.batch]

--- a/common/license_proxy_deploy/engine.toml
+++ b/common/license_proxy_deploy/engine.toml
@@ -62,6 +62,9 @@ use_v2_language_detection = false
 enabled = false # or true
 ### Specify the maximum number of concurrent streams to the Flux model in the Engine process
 # max_streams = 0 # Placeholder; required for production. Set explicitly based on GPU type.
+### Specify which Flux model to load. Options: "flux-general-en", "flux-general-multi"
+### If not present, defaults to "flux-general-en".
+# model_name = "flux-general-en"
 
 ### Size of audio chunks to process in seconds.
 [chunking.batch]

--- a/common/license_proxy_deploy/engine.toml
+++ b/common/license_proxy_deploy/engine.toml
@@ -59,11 +59,10 @@ use_v2_language_detection = false
 
 ### Enable Flux turn-based streaming STT
 [flux]
-enabled = false # or true
+enabled = false
 ### Specify the maximum number of concurrent streams to the Flux model in the Engine process
 # max_streams = 0 # Placeholder; required for production. Set explicitly based on GPU type.
-### Specify which Flux model to load. Options: "flux-general-en", "flux-general-multi"
-### If not present, defaults to "flux-general-en".
+### Specify which Flux model to load. Options: "flux-general-en" (default), "flux-general-multi"
 # model_name = "flux-general-en"
 
 ### Size of audio chunks to process in seconds.

--- a/common/standard_deploy/api.aura-2-en.toml
+++ b/common/standard_deploy/api.aura-2-en.toml
@@ -92,7 +92,7 @@ speak_streaming = true # or false
 # redact_usage = true # or false
 
 ### Enables Flux turn-based streaming STT
-listen_v2 = false # or true
+listen_v2 = false
 
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard

--- a/common/standard_deploy/api.aura-2-es.toml
+++ b/common/standard_deploy/api.aura-2-es.toml
@@ -92,7 +92,7 @@ speak_streaming = true # or false
 # redact_usage = true # or false
 
 ### Enables Flux turn-based streaming STT
-listen_v2 = false # or true
+listen_v2 = false
 
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard

--- a/common/standard_deploy/api.aura-2-polyglot.toml
+++ b/common/standard_deploy/api.aura-2-polyglot.toml
@@ -92,7 +92,7 @@ speak_streaming = true # or false
 # redact_usage = true # or false
 
 ### Enables Flux turn-based streaming STT
-listen_v2 = false # or true
+listen_v2 = false
 
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard

--- a/common/standard_deploy/api.flux.toml
+++ b/common/standard_deploy/api.flux.toml
@@ -1,0 +1,127 @@
+### Keep in mind that all paths are in-container paths, and do not need to exist
+### on the host machine.
+
+
+### Configure license validation by passing in a DEEPGRAM_API_KEY environment variable
+### See https://developers.deepgram.com/docs/deploy-deepgram-services#credentials
+[license]
+server_url = ["https://license.deepgram.com"]
+
+
+### Configure how the API will listen for your requests
+[server]
+### The base URL (prefix) for requests to the API.
+base_url = "/v1"
+### The IP address to listen on. Since this is likely running in a Docker
+### container, you will probably want to listen on all interfaces.
+host = "0.0.0.0"
+### The port to listen on
+port = 8080
+
+### How long to wait for a connection to a callback URL.
+callback_conn_timeout = "1s"
+### How long to wait for a response to a callback URL.
+callback_timeout = "10s"
+
+### How long to wait for a connection to a fetch URL.
+fetch_conn_timeout = "1s"
+### How long to wait for a response to a fetch URL.
+fetch_timeout = "60s"
+
+
+### By default, the API listens over HTTP. By passing both a certificate
+### and a key file, the API will instead listen over HTTPS.
+###
+### This performs TLS termination only, and does not provide any
+### additional authentication.
+[server.https]
+# cert_file = "/path/to/cert.pem"
+# key_file = "/path/to/key.pem"
+
+
+### Specify custom DNS resolution options.
+[resolver]
+### Specify custom domain name server(s).
+### Format is "{IP} {PORT} {PROTOCOL (tcp or udp)}"
+# nameservers = ["127.0.0.1 53 udp"]
+
+### If specifying a custom DNS nameserver, set the DNS TTL value.
+# max_ttl = 10
+
+
+### Limit the number of active requests handled by a single API container.
+### If additional requests beyond the limit are sent, API will return
+### a 429 HTTP status code. Default is no limit.
+[concurrency_limit]
+# active_requests =
+
+
+### Enable ancillary features
+[features]
+### Enables topic detection *if* a valid topic detection model is available
+topic_detection = true # or false
+
+### Enables summarization *if* a valid summarization model is available
+summarization = true # or false
+
+### Enables pre-recorded entity detection *if* a valid entity detection model is available
+entity_detection = false # or true
+
+### Enables pre-recorded entity-based redaction *if* a valid entity detection model is available
+entity_redaction = true # or false
+
+### Enables pre-recorded entity formatting *if* a valid NER model is available
+format_entity_tags = true # or false
+
+### If API is receiving requests faster than Engine can process them, a request
+### queue will form. By default, this queue is stored in memory. Under high load,
+### the queue may grow too large and cause Out-Of-Memory errors. To avoid this,
+### set a disk_buffer_path to buffer the overflow on the request queue to disk.
+###
+### WARN: This is only to temporarily buffer requests during high load.
+### If there is not enough Engine capacity to process the queued requests over time,
+### the queue (and response time) will grow indefinitely.
+# disk_buffer_path = "/path/to/disk/buffer/directory"
+
+### Enables streaming TTS *if* a valid Aura TTS model is available
+speak_streaming = true # or false
+
+### Toggles usage data redaction; set to false to disable redaction of usage data; defaults to true if not present
+# redact_usage = true # or false
+
+### Enables Flux turn-based streaming STT
+listen_v2 = true
+
+### Configure the backend pool of speech engines (generically referred to as
+### "drivers" here). The API will load-balance among drivers in the standard
+### pool; if one standard driver fails, the next one will be tried.
+###
+### Each driver URL will have its hostname resolved to an IP address. If a domain
+### name resolves to multiple IP addresses, the API will load-balance across each
+### IP address.
+###
+### This behavior is provided for convenience, and in a production environment
+### other tools can be used, such as HAProxy.
+###
+### Below is a new Speech Engine ("driver") in the "standard" pool.
+[[driver_pool.standard]]
+### Host to connect to. If you are using a different method of orchestrating,
+### then adjust the IP address accordingly.
+###
+### WARN: This must be HTTPS.
+###
+### Docker Compose and Podman Compose create a dedicated network that allows inter-container communication by app name.
+### See [Networking in Compose](https://docs.docker.com/compose/networking/) for details.
+url = "https://engine:8080/v2"
+### Factor to increase the timeout by for each additional retry (for
+### exponential backoff).
+timeout_backoff = 1.2
+
+### Before attempting a retry, sleep for this long (in seconds)
+retry_sleep = "2s"
+### Factor to increase the retry sleep by for each additional retry (for
+### exponential backoff).
+retry_backoff = 1.6
+
+### Maximum response to deserialize from Driver (in bytes)
+max_response_size = 1073741824 # 1GB

--- a/common/standard_deploy/api.toml
+++ b/common/standard_deploy/api.toml
@@ -90,7 +90,7 @@ speak_streaming = true # or false
 # redact_usage = true # or false
 
 ### Enables Flux turn-based streaming STT
-listen_v2 = false # or true
+listen_v2 = false
 
 ### Configure the backend pool of speech engines (generically referred to as
 ### "drivers" here). The API will load-balance among drivers in the standard

--- a/common/standard_deploy/engine.aura-2-en.toml
+++ b/common/standard_deploy/engine.aura-2-en.toml
@@ -57,7 +57,7 @@ streaming_ner = true # or false
 
 ### Enable Flux turn-based streaming STT
 [flux]
-enabled = false # or true
+enabled = false
 
 ### Size of audio chunks to process in seconds.
 [chunking.batch]

--- a/common/standard_deploy/engine.aura-2-es.toml
+++ b/common/standard_deploy/engine.aura-2-es.toml
@@ -57,7 +57,7 @@ streaming_ner = true # or false
 
 ### Enable Flux turn-based streaming STT
 [flux]
-enabled = false # or true
+enabled = false
 
 ### Size of audio chunks to process in seconds.
 [chunking.batch]

--- a/common/standard_deploy/engine.aura-2-polyglot.toml
+++ b/common/standard_deploy/engine.aura-2-polyglot.toml
@@ -57,7 +57,7 @@ streaming_ner = true # or false
 
 ### Enable Flux turn-based streaming STT
 [flux]
-enabled = false # or true
+enabled = false
 
 ### Size of audio chunks to process in seconds.
 [chunking.batch]

--- a/common/standard_deploy/engine.flux-en.toml
+++ b/common/standard_deploy/engine.flux-en.toml
@@ -52,17 +52,15 @@ multichannel = true # or false
 language_detection = true # or false
 ### Enables streaming entity formatting *if* a valid NER model is available
 streaming_ner = true # or false
-### Enables use of 36-language detection model
-use_v2_language_detection = false
 
 ### Enable Flux turn-based streaming STT
 [flux]
-enabled = false # or true
+enabled = true
 ### Specify the maximum number of concurrent streams to the Flux model in the Engine process
-# max_streams = 0 # Placeholder; required for production. Set explicitly based on GPU type.
+max_streams = 10
 ### Specify which Flux model to load. Options: "flux-general-en", "flux-general-multi"
 ### If not present, defaults to "flux-general-en".
-# model_name = "flux-general-en"
+model_name = "flux-general-en"
 
 ### Size of audio chunks to process in seconds.
 [chunking.batch]

--- a/common/standard_deploy/engine.flux-en.toml
+++ b/common/standard_deploy/engine.flux-en.toml
@@ -57,9 +57,8 @@ streaming_ner = true # or false
 [flux]
 enabled = true
 ### Specify the maximum number of concurrent streams to the Flux model in the Engine process
-max_streams = 10
-### Specify which Flux model to load. Options: "flux-general-en", "flux-general-multi"
-### If not present, defaults to "flux-general-en".
+# max_streams = 0 # Placeholder; required for production. Set explicitly based on GPU type.
+### Specify which Flux model to load. Options: "flux-general-en" (default), "flux-general-multi"
 model_name = "flux-general-en"
 
 ### Size of audio chunks to process in seconds.

--- a/common/standard_deploy/engine.flux-multi.toml
+++ b/common/standard_deploy/engine.flux-multi.toml
@@ -57,9 +57,8 @@ streaming_ner = true # or false
 [flux]
 enabled = true
 ### Specify the maximum number of concurrent streams to the Flux model in the Engine process
-max_streams = 10
-### Specify which Flux model to load. Options: "flux-general-en", "flux-general-multi"
-### If not present, defaults to "flux-general-en".
+# max_streams = 0 # Placeholder; required for production. Set explicitly based on GPU type.
+### Specify which Flux model to load. Options: "flux-general-en" (default), "flux-general-multi"
 model_name = "flux-general-multi"
 
 ### Size of audio chunks to process in seconds.

--- a/common/standard_deploy/engine.flux-multi.toml
+++ b/common/standard_deploy/engine.flux-multi.toml
@@ -52,17 +52,15 @@ multichannel = true # or false
 language_detection = true # or false
 ### Enables streaming entity formatting *if* a valid NER model is available
 streaming_ner = true # or false
-### Enables use of 36-language detection model
-use_v2_language_detection = false
 
 ### Enable Flux turn-based streaming STT
 [flux]
-enabled = false # or true
+enabled = true
 ### Specify the maximum number of concurrent streams to the Flux model in the Engine process
-# max_streams = 0 # Placeholder; required for production. Set explicitly based on GPU type.
+max_streams = 10
 ### Specify which Flux model to load. Options: "flux-general-en", "flux-general-multi"
 ### If not present, defaults to "flux-general-en".
-# model_name = "flux-general-en"
+model_name = "flux-general-multi"
 
 ### Size of audio chunks to process in seconds.
 [chunking.batch]

--- a/common/standard_deploy/engine.toml
+++ b/common/standard_deploy/engine.toml
@@ -57,11 +57,10 @@ use_v2_language_detection = false
 
 ### Enable Flux turn-based streaming STT
 [flux]
-enabled = false # or true
+enabled = false
 ### Specify the maximum number of concurrent streams to the Flux model in the Engine process
 # max_streams = 0 # Placeholder; required for production. Set explicitly based on GPU type.
-### Specify which Flux model to load. Options: "flux-general-en", "flux-general-multi"
-### If not present, defaults to "flux-general-en".
+### Specify which Flux model to load. Options: "flux-general-en" (default), "flux-general-multi"
 # model_name = "flux-general-en"
 
 ### Size of audio chunks to process in seconds.

--- a/docker/docker-compose.aura-2-polyglot.yml
+++ b/docker/docker-compose.aura-2-polyglot.yml
@@ -10,7 +10,7 @@ services:
   # The speech API service.
   # English Language Aura-2
   api-en:
-    image: quay.io/deepgram/self-hosted-api:release-260402
+    image: quay.io/deepgram/self-hosted-api:release-260416
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -37,7 +37,7 @@ services:
 
   # Polyglot Aura-2 (Dutch, German, French, Italian, Japanese)
   api-polyglot:
-    image: quay.io/deepgram/self-hosted-api:release-260402
+    image: quay.io/deepgram/self-hosted-api:release-260416
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -65,7 +65,7 @@ services:
   # The speech engine service.
   # English Language Aura-2 Driver
   engine-en:
-    image: quay.io/deepgram/self-hosted-engine:release-260402
+    image: quay.io/deepgram/self-hosted-engine:release-260416
     restart: always
 
     # Utilize a GPU, if available.
@@ -98,7 +98,7 @@ services:
 
   # Polyglot (Dutch, German, French, Italian, Japanese) Aura-2 Driver
   engine-polyglot:
-    image: quay.io/deepgram/self-hosted-engine:release-260402
+    image: quay.io/deepgram/self-hosted-engine:release-260416
     restart: always
 
     # Utilize a GPU, if available.
@@ -131,7 +131,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260402
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260416
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/docker/docker-compose.aura-2.yml
+++ b/docker/docker-compose.aura-2.yml
@@ -10,7 +10,7 @@ services:
   # The speech API service.
   # English Language Aura-2
   api-en:
-    image: quay.io/deepgram/self-hosted-api:release-260402
+    image: quay.io/deepgram/self-hosted-api:release-260416
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -37,7 +37,7 @@ services:
 
   # Spanish Language Aura-2
   api-es:
-    image: quay.io/deepgram/self-hosted-api:release-260402
+    image: quay.io/deepgram/self-hosted-api:release-260416
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -65,7 +65,7 @@ services:
   # The speech engine service.
   # English Language Aura-2 Driver
   engine-en:
-    image: quay.io/deepgram/self-hosted-engine:release-260402
+    image: quay.io/deepgram/self-hosted-engine:release-260416
     restart: always
 
     # Utilize a GPU, if available.
@@ -98,7 +98,7 @@ services:
 
   # Spanish Language Aura-2 Driver
   engine-es:
-    image: quay.io/deepgram/self-hosted-engine:release-260402
+    image: quay.io/deepgram/self-hosted-engine:release-260416
     restart: always
 
     # Utilize a GPU, if available.
@@ -131,7 +131,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260402
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260416
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/docker/docker-compose.license-proxy.yml
+++ b/docker/docker-compose.license-proxy.yml
@@ -9,7 +9,7 @@ x-env: &env
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-260402
+    image: quay.io/deepgram/self-hosted-api:release-260416
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -35,7 +35,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-260402
+    image: quay.io/deepgram/self-hosted-engine:release-260416
     restart: always
 
     # Utilize a GPU, if available.
@@ -63,7 +63,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260402
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260416
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/docker/docker-compose.standard.yml
+++ b/docker/docker-compose.standard.yml
@@ -9,7 +9,7 @@ x-env: &env
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-260402
+    image: quay.io/deepgram/self-hosted-api:release-260416
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -31,7 +31,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-260402
+    image: quay.io/deepgram/self-hosted-engine:release-260416
     restart: always
 
     # Utilize a GPU, if available.

--- a/podman/podman-compose.aura-2.yml
+++ b/podman/podman-compose.aura-2.yml
@@ -4,7 +4,7 @@ services:
   # The speech API service.
   # English Language Aura-2
   api-en:
-    image: quay.io/deepgram/self-hosted-api:release-260402
+    image: quay.io/deepgram/self-hosted-api:release-260416
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -33,7 +33,7 @@ services:
 
   # Spanish Language Aura-2
   api-es:
-    image: quay.io/deepgram/self-hosted-api:release-260402
+    image: quay.io/deepgram/self-hosted-api:release-260416
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -63,7 +63,7 @@ services:
   # The speech engine service.
   # English Language Aura-2 Driver
   engine-en:
-    image: quay.io/deepgram/self-hosted-engine:release-260402
+    image: quay.io/deepgram/self-hosted-engine:release-260416
     restart: always
 
     # Utilize a GPU, if available.
@@ -99,7 +99,7 @@ services:
 
   # Spanish Language Aura-2 Driver
   engine-es:
-    image: quay.io/deepgram/self-hosted-engine:release-260402
+    image: quay.io/deepgram/self-hosted-engine:release-260416
     restart: always
 
     # Utilize a GPU, if available.
@@ -135,7 +135,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260402
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260416
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/podman/podman-compose.license-proxy.yml
+++ b/podman/podman-compose.license-proxy.yml
@@ -3,7 +3,7 @@
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-260402
+    image: quay.io/deepgram/self-hosted-api:release-260416
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -32,7 +32,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-260402
+    image: quay.io/deepgram/self-hosted-engine:release-260416
     restart: always
 
     # Utilize a GPU, if available.
@@ -64,7 +64,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260402
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260416
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/podman/podman-compose.standard.yml
+++ b/podman/podman-compose.standard.yml
@@ -3,7 +3,7 @@
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-260402
+    image: quay.io/deepgram/self-hosted-api:release-260416
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -28,7 +28,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-260402
+    image: quay.io/deepgram/self-hosted-engine:release-260416
     restart: always
 
     # Utilize a GPU, if available.


### PR DESCRIPTION
## Summary

- Add Flux STT config variants (`engine.flux-en.toml`, `engine.flux-multi.toml`, `api.flux.toml`) for both standard and license-proxy deploy types. Flux Multilingual requires `model_name = "flux-general-multi"` in `engine.toml` — without it, Engine silently defaults to English-only inference.
- Add commented-out `model_name` to base `engine.toml` files so existing Flux users see the option.
- Bump all container tags from `release-260402` to `release-260416` (API 1.181.7, Engine 3.115.1, License Proxy 1.10.1, Billing 1.13.0).
- Helm chart 0.33.0 -> 0.34.0 with CHANGELOG entry.

## Context

Flux Multilingual is GA in the 260416 release. Engine requires an explicit `model_name` config key to load the Multi model weights — otherwise it falls back to `flux-general-en`. 

## Test plan

- [x] Verified `engine.flux-multi.toml` on `flux-stt-test.deepgram.com` with public `release-260416` tags
- [x] German, French, and English audio all transcribe correctly with proper `languages` field
- [x] `helm-docs` README regenerated
- [x] No stale `release-260402` tags remain in yml/yaml files