### PR TITLE
feat(engine): support configurable HTTP readiness probe for engine pods

### DIFF
--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -203,8 +203,14 @@ spec:
           periodSeconds: {{ $.Values.engine.livenessProbe.periodSeconds }}
           failureThreshold: {{ $.Values.engine.livenessProbe.failureThreshold }}
         readinessProbe:
+          {{- if $.Values.engine.readinessProbe.httpGet }}
+          httpGet:
+            path: {{ $.Values.engine.readinessProbe.httpGet.path }}
+            port: {{ $.Values.engine.server.port }}
+          {{- else }}
           tcpSocket:
             port: {{ $.Values.engine.server.port }}
+          {{- end }}
           initialDelaySeconds: {{ $.Values.engine.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ $.Values.engine.readinessProbe.periodSeconds }}
           failureThreshold: {{ $.Values.engine.readinessProbe.failureThreshold }}

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -556,6 +556,10 @@ engine:
     initialDelaySeconds: 5
     periodSeconds: 10
     failureThreshold: 1
+    # -- (object) Set to use an HTTP GET probe instead of the default TCP socket probe.
+    # Example: { path: "/v1/status/engine" }
+    # httpGet:
+    #   path: /v1/status/engine
   # -- Liveness probe customization for Engine pods.
   # @default -- ``
   livenessProbe:


### PR DESCRIPTION
## Summary

- Adds optional `httpGet` configuration for the engine **readiness probe** only
- When `readinessProbe.httpGet.path` is set (e.g., `/v1/status/engine`), the probe uses an HTTP GET request instead of the default TCP socket check
- Startup and liveness probes remain `tcpSocket` (unchanged)
- Defaults to `tcpSocket` (no behavior change for existing deployments)

## Motivation

The Deepgram docs [recommend](https://developers.deepgram.com/docs/self-hosted-status-endpoint) using the `/v1/status/engine` endpoint for health checking, which returns structured status information (Initializing, Ready, Healthy, Critical). The current `tcpSocket` readiness probe only verifies the port is open, not that the engine is in a healthy state to serve inference. Using `httpGet` for the readiness probe allows Kubernetes to remove pods from service when they report unhealthy status, without restarting them.

## Usage

```yaml
engine:
  readinessProbe:
    httpGet:
      path: /v1/status/engine
```

Omitting `httpGet` preserves the existing `tcpSocket` behavior.

## Test plan

- [ ] Verify default behavior (no `httpGet` set) still uses `tcpSocket` — `helm template` output should be unchanged
- [ ] Verify setting `readinessProbe.httpGet.path` switches readiness to HTTP probe
- [ ] Verify startup and liveness probes are unaffected regardless of readiness config