### PR TITLE
Upgrade Kubernetes version to 1.35 in AWS cluster configs

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+### Changed
+
+- Updated sample cluster configuration files to use Kubernetes 1.35 (previously 1.33)
+
 ## [0.35.1] - 2026-05-01
 
 ### Changed

--- a/charts/deepgram-self-hosted/samples/01-basic-setup-aws.cluster-config.yaml
+++ b/charts/deepgram-self-hosted/samples/01-basic-setup-aws.cluster-config.yaml
@@ -4,7 +4,7 @@ kind: ClusterConfig
 metadata:
   name: deepgram-self-hosted-cluster
   region: us-west-2
-  version: "1.33"
+  version: "1.35"
 
 iam:
   withOIDC: true

--- a/charts/deepgram-self-hosted/samples/05-voice-agent-aws.cluster-config.yaml
+++ b/charts/deepgram-self-hosted/samples/05-voice-agent-aws.cluster-config.yaml
@@ -4,7 +4,7 @@ kind: ClusterConfig
 metadata:
   name: deepgram-self-hosted-voice-agent-cluster # Change to your desired name
   region: us-west-2 # Change to your desired host region
-  version: "1.33"
+  version: "1.35"
 
 iam:
   withOIDC: true

--- a/charts/deepgram-self-hosted/samples/07-basic-setup-aws-airgapped.cluster-config.yaml
+++ b/charts/deepgram-self-hosted/samples/07-basic-setup-aws-airgapped.cluster-config.yaml
@@ -4,7 +4,7 @@ kind: ClusterConfig
 metadata:
   name: deepgram-self-hosted-cluster
   region: us-west-2
-  version: "1.33"
+  version: "1.35"
 
 iam:
   withOIDC: true

--- a/charts/deepgram-self-hosted/samples/voice-agent/aws/self-hosted-llm/cluster-config.yaml
+++ b/charts/deepgram-self-hosted/samples/voice-agent/aws/self-hosted-llm/cluster-config.yaml
@@ -11,7 +11,7 @@ kind: ClusterConfig
 metadata:
   name: deepgram-voice-agent-llm-cluster # Change to your desired name
   region: us-west-2 # Change to your desired host region
-  version: "1.33"
+  version: "1.35"
 
 iam:
   withOIDC: true


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Upgrade Kubernetes version from 1.33 to 1.35 in AWS cluster configs ahead of end-of-support.

See AWS EKS doc: [Understand the Kubernetes version lifecycle on EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)

Kubernetes 1.33 (Deepgram chart's prior version):
- Standard support ends July 29, 2026 [in less than 3 months]
- Extended support ends July 29, 2027

Kubernetes 1.35 (Deepgram chart's new version): 
- Standard support ends March 27, 2027
- Extended support ends March 27, 2028

I tested in EKS and it works as expected, no issues updating a Deepgram cluster from 1.33 to 1.35 and serving requests.

## Types of changes

What types of changes does your code introduce to the Deepgram self-hosted resources?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have tested my changes in my local self-hosted environment
  - Please describe your testing setup and methodology here
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
