### PR TITLE
Add support for setting priority classes on deployments

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+### Added
+
+- Added `priorityClassName` to the API, Engine, License Proxy, and Billing components, allowing a Kubernetes [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) to be assigned to each component's pods. Defaults to `""` (empty), which omits the field and preserves existing scheduling behavior.
+
 ## [0.38.0] - 2026-06-11
 
 ### Changed

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -285,6 +285,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | api.livenessProbe | object | `` | Liveness probe customization for API pods. |
 | api.namePrefix | string | `"deepgram-api"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram API containers. |
 | api.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to API pods. |
+| api.priorityClassName | string | `""` | [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) name to apply to API pods. Leave empty to omit the field. |
 | api.readinessProbe | object | `` | Readiness probe customization for API pods. |
 | api.resolver | object | `` | Specify custom DNS resolution options. |
 | api.resolver.maxTTL | int | `nil` | maxTTL sets the DNS TTL value if specifying a custom DNS nameserver. |
@@ -337,6 +338,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | billing.livenessProbe | object | `` | Liveness probe customization for Billing pods. |
 | billing.namePrefix | string | `"deepgram-billing"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram Billing containers. |
 | billing.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to Billing pods. |
+| billing.priorityClassName | string | `""` | [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) name to apply to Billing pods. Leave empty to omit the field. |
 | billing.readinessProbe | object | `` | Readiness probe customization for Billing pods. |
 | billing.replicas | int | `1` | Number of Billing replicas. Default is 1 (singleton). Can be increased for high availability. Each replica maintains its own journal file. |
 | billing.resources | object | `` | Configure resource limits per Billing container. |
@@ -410,6 +412,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | engine.modelManager.volumes.gcp.gpd.volumeHandle | string | `""` | The identifier of your pre-existing persistent disk. The format is projects/{project_id}/zones/{zone_name}/disks/{disk_name} for Zonal persistent disks, or projects/{project_id}/regions/{region_name}/disks/{disk_name} for Regional persistent disks. |
 | engine.namePrefix | string | `"deepgram-engine"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram Engine containers. |
 | engine.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to Engine pods. |
+| engine.priorityClassName | string | `""` | [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) name to apply to Engine pods. Leave empty to omit the field. |
 | engine.readinessProbe | object | `` | Readiness probe customization for Engine pods. |
 | engine.resources | object | `` | Configure resource limits per Engine container. See [Deepgram's documentation](https://developers.deepgram.com/docs/self-hosted-deployment-environments#engine) for more details. |
 | engine.resources.gpuResourceName | string | `"nvidia.com/gpu"` | Name of the GPU resource to use (e.g., nvidia.com/gpu for standard GPUs, or nvidia.com/mig-4g.40gb for MIG slices). This allows using different GPU resource naming conventions as configured by the NVIDIA GPU Operator. |
@@ -468,6 +471,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | licenseProxy.livenessProbe | object | `` | Liveness probe customization for Proxy pods. |
 | licenseProxy.namePrefix | string | `"deepgram-license-proxy"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram License Proxy containers. |
 | licenseProxy.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to License Proxy pods. |
+| licenseProxy.priorityClassName | string | `""` | [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) name to apply to License Proxy pods. Leave empty to omit the field. |
 | licenseProxy.readinessProbe | object | `` | Readiness probe customization for License Proxy pods. |
 | licenseProxy.resources | object | `` | Configure resource limits per License Proxy container. See [Deepgram's documentation](https://developers.deepgram.com/docs/license-proxy#system-requirements) for more details. |
 | licenseProxy.securityContext | object | `{}` | [Pod-level security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) for License Proxy pods. |

--- a/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
@@ -48,6 +48,9 @@ spec:
         {{- toYaml .Values.api.topologySpreadConstraints | nindent 8 }}
       nodeSelector:
         {{- toYaml .Values.api.nodeSelector | nindent 8 }}
+      {{- with .Values.api.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.api.securityContext | nindent 8 }}
       {{- if or .Values.api.serviceAccount.create .Values.api.serviceAccount.name }}

--- a/charts/deepgram-self-hosted/templates/billing/billing.statefulset.yaml
+++ b/charts/deepgram-self-hosted/templates/billing/billing.statefulset.yaml
@@ -46,6 +46,9 @@ spec:
         {{- toYaml .Values.billing.topologySpreadConstraints | nindent 8 }}
       nodeSelector:
         {{- toYaml .Values.billing.nodeSelector | nindent 8 }}
+      {{- with .Values.billing.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.billing.securityContext | nindent 8 }}
       {{- if or .Values.billing.serviceAccount.create .Values.billing.serviceAccount.name }}

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -68,6 +68,9 @@ spec:
         {{- toYaml $.Values.engine.topologySpreadConstraints | nindent 8 }}
       nodeSelector:
         {{- toYaml $.Values.engine.nodeSelector | nindent 8 }}
+      {{- with $.Values.engine.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with $.Values.engine.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
@@ -45,6 +45,9 @@ spec:
         {{- toYaml .Values.licenseProxy.topologySpreadConstraints | nindent 8 }}
       nodeSelector:
         {{- toYaml .Values.licenseProxy.nodeSelector | nindent 8 }}
+      {{- with .Values.licenseProxy.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.licenseProxy.securityContext | nindent 8 }}
       {{- if or .Values.licenseProxy.serviceAccount.create .Values.licenseProxy.serviceAccount.name }}

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -328,6 +328,10 @@ api:
   # to apply to API pods.
   nodeSelector: {}
 
+  # -- (string) [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+  # name to apply to API pods. Leave empty to omit the field.
+  priorityClassName: ""
+
   # -- [Topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field)
   # to apply to API pods.
   topologySpreadConstraints: []
@@ -604,6 +608,10 @@ engine:
   # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
   # to apply to Engine pods.
   nodeSelector: {}
+
+  # -- (string) [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+  # name to apply to Engine pods. Leave empty to omit the field.
+  priorityClassName: ""
 
   # -- (string) [Runtime class](https://kubernetes.io/docs/concepts/containers/runtime-class/)
   # to use for Engine pods. Set to "nvidia" when using KOPS-managed NVIDIA drivers
@@ -930,6 +938,10 @@ licenseProxy:
   # to apply to License Proxy pods.
   nodeSelector: {}
 
+  # -- (string) [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+  # name to apply to License Proxy pods. Leave empty to omit the field.
+  priorityClassName: ""
+
   # -- [Pod-level security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) for License Proxy pods.
   securityContext: {}
 
@@ -1108,6 +1120,10 @@ billing:
   # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
   # to apply to Billing pods.
   nodeSelector: {}
+
+  # -- (string) [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+  # name to apply to Billing pods. Leave empty to omit the field.
+  priorityClassName: ""
 
   # -- [Pod-level security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) for Billing pods.
   securityContext: {}


### PR DESCRIPTION
## Proposed changes

[Adds `priorityClassName`](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) support to the Deepgram self-hosted Helm charts, allowing operators to assign Kubernetes priority classes to the `api`, `engine`, `licenseProxy`, and `billing` workloads. This enables better scheduling control in resource-constrained clusters.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have tested my changes in my local self-hosted environment
  - Tested using `helm template` to validate rendering with and without `priorityClassName` values set.
  - **Test 1** (values set): Confirmed `priorityClassName` appears in rendered output for `api`, `engine`, `licenseProxy`, and `billing` by grepping for `priorityClassName` in the full template output.
  - **Test 2** (no values set): Confirmed `priorityClassName` does **not** appear in the rendered deployment/statefulset manifests when no priority class is specified, by asserting a grep count of `0` across all four workload templates.
- [x] I have added necessary documentation (if appropriate)

## Further comments

The implementation conditionally renders `priorityClassName` only when a value is provided, so existing deployments are unaffected. Each workload (`api`, `engine`, `licenseProxy`, `billing`) accepts its own independent priority class value, giving operators fine-grained control — for example, assigning `high-gpu` to the engine while keeping billing on `low`.