### PR TITLE
Add PodDisruptionBudget support for all workloads

### DIFF
--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -285,6 +285,10 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | api.livenessProbe | object | `` | Liveness probe customization for API pods. |
 | api.namePrefix | string | `"deepgram-api"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram API containers. |
 | api.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to API pods. |
+| api.pdb | object | `` | [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) for API pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled. |
+| api.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for API pods. |
+| api.pdb.maxUnavailable | int|string | `nil` | Maximum unavailable API pods. Integer or percentage string (e.g. "50%"). |
+| api.pdb.minAvailable | int|string | `nil` | Minimum available API pods. Integer or percentage string (e.g. "50%"). |
 | api.readinessProbe | object | `` | Readiness probe customization for API pods. |
 | api.resolver | object | `` | Specify custom DNS resolution options. |
 | api.resolver.maxTTL | int | `nil` | maxTTL sets the DNS TTL value if specifying a custom DNS nameserver. |
@@ -337,6 +341,10 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | billing.livenessProbe | object | `` | Liveness probe customization for Billing pods. |
 | billing.namePrefix | string | `"deepgram-billing"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram Billing containers. |
 | billing.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to Billing pods. |
+| billing.pdb | object | `` | [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) for Billing pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled. |
+| billing.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for Billing pods. |
+| billing.pdb.maxUnavailable | int|string | `nil` | Maximum unavailable Billing pods. Integer or percentage string (e.g. "50%"). |
+| billing.pdb.minAvailable | int|string | `nil` | Minimum available Billing pods. Integer or percentage string (e.g. "50%"). |
 | billing.readinessProbe | object | `` | Readiness probe customization for Billing pods. |
 | billing.replicas | int | `1` | Number of Billing replicas. Default is 1 (singleton). Can be increased for high availability. Each replica maintains its own journal file. |
 | billing.resources | object | `` | Configure resource limits per Billing container. |
@@ -410,6 +418,10 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | engine.modelManager.volumes.gcp.gpd.volumeHandle | string | `""` | The identifier of your pre-existing persistent disk. The format is projects/{project_id}/zones/{zone_name}/disks/{disk_name} for Zonal persistent disks, or projects/{project_id}/regions/{region_name}/disks/{disk_name} for Regional persistent disks. |
 | engine.namePrefix | string | `"deepgram-engine"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram Engine containers. |
 | engine.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to Engine pods. |
+| engine.pdb | object | `` | [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) for Engine pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled. When `agent.enabled` is true, one PDB is created per engine-type (speech-to-text, text-to-speech, end-of-turn), each with the same budget values. |
+| engine.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for Engine pods. |
+| engine.pdb.maxUnavailable | int|string | `nil` | Maximum unavailable Engine pods. Integer or percentage string (e.g. "50%"). |
+| engine.pdb.minAvailable | int|string | `nil` | Minimum available Engine pods. Integer or percentage string (e.g. "50%"). |
 | engine.readinessProbe | object | `` | Readiness probe customization for Engine pods. |
 | engine.resources | object | `` | Configure resource limits per Engine container. See [Deepgram's documentation](https://developers.deepgram.com/docs/self-hosted-deployment-environments#engine) for more details. |
 | engine.resources.gpuResourceName | string | `"nvidia.com/gpu"` | Name of the GPU resource to use (e.g., nvidia.com/gpu for standard GPUs, or nvidia.com/mig-4g.40gb for MIG slices). This allows using different GPU resource naming conventions as configured by the NVIDIA GPU Operator. |
@@ -468,6 +480,10 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | licenseProxy.livenessProbe | object | `` | Liveness probe customization for Proxy pods. |
 | licenseProxy.namePrefix | string | `"deepgram-license-proxy"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram License Proxy containers. |
 | licenseProxy.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to License Proxy pods. |
+| licenseProxy.pdb | object | `` | [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) for License Proxy pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled. |
+| licenseProxy.pdb.enabled | bool | `false` | Whether to create a PodDisruptionBudget for License Proxy pods. |
+| licenseProxy.pdb.maxUnavailable | int|string | `nil` | Maximum unavailable License Proxy pods. Integer or percentage string (e.g. "50%"). |
+| licenseProxy.pdb.minAvailable | int|string | `nil` | Minimum available License Proxy pods. Integer or percentage string (e.g. "50%"). |
 | licenseProxy.readinessProbe | object | `` | Readiness probe customization for License Proxy pods. |
 | licenseProxy.resources | object | `` | Configure resource limits per License Proxy container. See [Deepgram's documentation](https://developers.deepgram.com/docs/license-proxy#system-requirements) for more details. |
 | licenseProxy.securityContext | object | `{}` | [Pod-level security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) for License Proxy pods. |

--- a/charts/deepgram-self-hosted/templates/api/api.pdb.yaml
+++ b/charts/deepgram-self-hosted/templates/api/api.pdb.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.api.pdb.enabled }}
+{{- if and (kindIs "invalid" .Values.api.pdb.minAvailable) (kindIs "invalid" .Values.api.pdb.maxUnavailable) }}
+{{- fail "api.pdb.enabled is true but neither api.pdb.minAvailable nor api.pdb.maxUnavailable is set" }}
+{{- end }}
+{{- if and (not (kindIs "invalid" .Values.api.pdb.minAvailable)) (not (kindIs "invalid" .Values.api.pdb.maxUnavailable)) }}
+{{- fail "api.pdb.minAvailable and api.pdb.maxUnavailable are mutually exclusive" }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.api.namePrefix }}
+  labels:
+{{ include "deepgram-self-hosted.labels" . | indent 4 }}
+    app: {{ .Values.api.namePrefix }}
+    {{- range $key, $val := .Values.api.additionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+spec:
+  {{- with .Values.api.pdb.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.api.pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ .Values.api.namePrefix }}
+      {{ include "deepgram-self-hosted.selectorLabels" . }}
+{{- end }}

--- a/charts/deepgram-self-hosted/templates/billing/billing.pdb.yaml
+++ b/charts/deepgram-self-hosted/templates/billing/billing.pdb.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.billing.enabled .Values.billing.pdb.enabled }}
+{{- if and (kindIs "invalid" .Values.billing.pdb.minAvailable) (kindIs "invalid" .Values.billing.pdb.maxUnavailable) }}
+{{- fail "billing.pdb.enabled is true but neither billing.pdb.minAvailable nor billing.pdb.maxUnavailable is set" }}
+{{- end }}
+{{- if and (not (kindIs "invalid" .Values.billing.pdb.minAvailable)) (not (kindIs "invalid" .Values.billing.pdb.maxUnavailable)) }}
+{{- fail "billing.pdb.minAvailable and billing.pdb.maxUnavailable are mutually exclusive" }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.billing.namePrefix }}
+  labels:
+{{ include "deepgram-self-hosted.labels" . | indent 4 }}
+    app: deepgram-billing
+    {{- range $key, $val := .Values.billing.additionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+spec:
+  {{- with .Values.billing.pdb.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.billing.pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: deepgram-billing
+      {{ include "deepgram-self-hosted.selectorLabels" . }}
+{{- end }}

--- a/charts/deepgram-self-hosted/templates/engine/engine.pdb.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.pdb.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.engine.pdb.enabled }}
+{{- if and (kindIs "invalid" .Values.engine.pdb.minAvailable) (kindIs "invalid" .Values.engine.pdb.maxUnavailable) }}
+{{- fail "engine.pdb.enabled is true but neither engine.pdb.minAvailable nor engine.pdb.maxUnavailable is set" }}
+{{- end }}
+{{- if and (not (kindIs "invalid" .Values.engine.pdb.minAvailable)) (not (kindIs "invalid" .Values.engine.pdb.maxUnavailable)) }}
+{{- fail "engine.pdb.minAvailable and engine.pdb.maxUnavailable are mutually exclusive" }}
+{{- end }}
+{{- $engineTypes := list }}
+{{- if .Values.agent.enabled }}
+{{- $engineTypes = list "agent-speech-to-text" "agent-text-to-speech" "agent-end-of-turn" }}
+{{- else }}
+{{- $engineTypes = list "" }}
+{{- end }}
+{{- range $type := $engineTypes }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $.Values.engine.namePrefix }}{{- if $type }}-{{ $type }}{{- end }}
+  labels:
+{{ include "deepgram-self-hosted.labels" $ | indent 4 }}
+    app: {{ $.Values.engine.namePrefix }}
+    {{- if $type }}
+    engine-type: {{ $type }}
+    {{- end }}
+    {{- range $key, $val := $.Values.engine.additionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+spec:
+  {{- with $.Values.engine.pdb.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with $.Values.engine.pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ $.Values.engine.namePrefix }}
+      {{- if $type }}
+      engine-type: {{ $type }}
+      {{- end }}
+      {{ include "deepgram-self-hosted.selectorLabels" $ }}
+{{- end }}
+{{- end }}

--- a/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.pdb.yaml
+++ b/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.pdb.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.licenseProxy.enabled .Values.licenseProxy.pdb.enabled }}
+{{- if and (kindIs "invalid" .Values.licenseProxy.pdb.minAvailable) (kindIs "invalid" .Values.licenseProxy.pdb.maxUnavailable) }}
+{{- fail "licenseProxy.pdb.enabled is true but neither licenseProxy.pdb.minAvailable nor licenseProxy.pdb.maxUnavailable is set" }}
+{{- end }}
+{{- if and (not (kindIs "invalid" .Values.licenseProxy.pdb.minAvailable)) (not (kindIs "invalid" .Values.licenseProxy.pdb.maxUnavailable)) }}
+{{- fail "licenseProxy.pdb.minAvailable and licenseProxy.pdb.maxUnavailable are mutually exclusive" }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.licenseProxy.namePrefix }}
+  labels:
+{{ include "deepgram-self-hosted.labels" . | indent 4 }}
+    app: {{ .Values.licenseProxy.namePrefix }}
+    {{- range $key, $val := .Values.licenseProxy.additionalLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+spec:
+  {{- with .Values.licenseProxy.pdb.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.licenseProxy.pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ .Values.licenseProxy.namePrefix }}
+      {{ include "deepgram-self-hosted.selectorLabels" . }}
+{{- end }}

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -328,6 +328,17 @@ api:
   # to apply to API pods.
   nodeSelector: {}
 
+  # -- [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
+  # for API pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled.
+  # @default -- ``
+  pdb:
+    # -- Whether to create a PodDisruptionBudget for API pods.
+    enabled: false
+    # -- (int|string) Minimum available API pods. Integer or percentage string (e.g. "50%").
+    minAvailable:
+    # -- (int|string) Maximum unavailable API pods. Integer or percentage string (e.g. "50%").
+    maxUnavailable:
+
   # -- [Topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field)
   # to apply to API pods.
   topologySpreadConstraints: []
@@ -604,6 +615,19 @@ engine:
   # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
   # to apply to Engine pods.
   nodeSelector: {}
+
+  # -- [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
+  # for Engine pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled.
+  # When `agent.enabled` is true, one PDB is created per engine-type (speech-to-text, text-to-speech, end-of-turn),
+  # each with the same budget values.
+  # @default -- ``
+  pdb:
+    # -- Whether to create a PodDisruptionBudget for Engine pods.
+    enabled: false
+    # -- (int|string) Minimum available Engine pods. Integer or percentage string (e.g. "50%").
+    minAvailable:
+    # -- (int|string) Maximum unavailable Engine pods. Integer or percentage string (e.g. "50%").
+    maxUnavailable:
 
   # -- (string) [Runtime class](https://kubernetes.io/docs/concepts/containers/runtime-class/)
   # to use for Engine pods. Set to "nvidia" when using KOPS-managed NVIDIA drivers
@@ -930,6 +954,17 @@ licenseProxy:
   # to apply to License Proxy pods.
   nodeSelector: {}
 
+  # -- [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
+  # for License Proxy pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled.
+  # @default -- ``
+  pdb:
+    # -- Whether to create a PodDisruptionBudget for License Proxy pods.
+    enabled: false
+    # -- (int|string) Minimum available License Proxy pods. Integer or percentage string (e.g. "50%").
+    minAvailable:
+    # -- (int|string) Maximum unavailable License Proxy pods. Integer or percentage string (e.g. "50%").
+    maxUnavailable:
+
   # -- [Pod-level security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) for License Proxy pods.
   securityContext: {}
 
@@ -1108,6 +1143,17 @@ billing:
   # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
   # to apply to Billing pods.
   nodeSelector: {}
+
+  # -- [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
+  # for Billing pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled.
+  # @default -- ``
+  pdb:
+    # -- Whether to create a PodDisruptionBudget for Billing pods.
+    enabled: false
+    # -- (int|string) Minimum available Billing pods. Integer or percentage string (e.g. "50%").
+    minAvailable:
+    # -- (int|string) Maximum unavailable Billing pods. Integer or percentage string (e.g. "50%").
+    maxUnavailable:
 
   # -- [Pod-level security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) for Billing pods.
   securityContext: {}


### PR DESCRIPTION
## Proposed changes
Adds optional PodDisruptionBudget resources for API, Engine, License Proxy, and Billing workloads. Each component exposes `pdb.enabled`, `pdb.minAvailable`, and `pdb.maxUnavailable` under its values block. Disabled by default. Template render fails if enabled with neither or both of min/maxAvailable set.

When `agent.enabled=true`, one Engine PDB is emitted per engine-type (speech-to-text, text-to-speech, end-of-turn), mirroring the engine Deployment loop, with each PDB sharing the configured budget values.

## Types of changes

What types of changes does your code introduce to the Deepgram self-hosted resources?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] I have tested my changes in my local self-hosted environment
  - Please describe your testing setup and methodology here
- [X] I have added necessary documentation (if appropriate)
