### PR TITLE
Re-add Nvidia GPU exposure variables for Docker refactor.

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+### Added
+
+- Re-added `NVIDIA_VISIBLE_DEVICES=all` and `NVIDIA_DRIVER_CAPABILITIES=compute,utility` on Engine pods when GPUs are requested, and on all Docker and Podman compose files. **Required for `release-260430` and later** — the Engine image no longer bakes these env vars in, and without them the container will fail to start with `libcuda.so.1: cannot open shared object file`.
+
 ## [0.36.0] - 2026-05-14
 
 ### Changed

--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Re-added `NVIDIA_VISIBLE_DEVICES=all` and `NVIDIA_DRIVER_CAPABILITIES=compute,utility` on Engine pods when GPUs are requested, and on all Docker and Podman compose files. **Required for `release-260430` and later** — the Engine image no longer bakes these env vars in, and without them the container will fail to start with `libcuda.so.1: cannot open shared object file`.
+- Re-added `NVIDIA_VISIBLE_DEVICES=all` and `NVIDIA_DRIVER_CAPABILITIES=compute,utility` on Engine pods when GPUs are requested, and on all Docker and Podman compose files. **Required for `release-260528` and later** — the Engine image no longer bakes these env vars in, and without them the container will fail to start with `libcuda.so.1: cannot open shared object file`.
 
 ## [0.36.0] - 2026-05-14
 

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -141,6 +141,14 @@ spec:
         {{- if le $gpuRequest 0 }}
         - name: NVIDIA_VISIBLE_DEVICES
           value: "void"
+        {{- else }}
+        # Required for the Engine container to access the GPU. The nvidia-container-runtime
+        # only injects CUDA libraries when these are set; without them the Engine container
+        # will fail to start with `libcuda.so.1: cannot open shared object file`.
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: "all"
+        - name: NVIDIA_DRIVER_CAPABILITIES
+          value: "compute,utility"
         {{- end }}
         {{- if and $.Values.aura2.enabled (or (not $.Values.agent.enabled) (eq $type "agent-text-to-speech")) }}
         {{- if $.Values.aura2.english.enabled }}

--- a/docker/docker-compose.aura-2-polyglot.yml
+++ b/docker/docker-compose.aura-2-polyglot.yml
@@ -5,6 +5,11 @@ x-env-vars: &env
   # Be sure to use the &env anchor inside an 'environment' mapping for a given service
   DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
   DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "docker-compose"
+  # Required for the Engine container to access the GPU. The nvidia-container-runtime
+  # only injects CUDA libraries when these are set; without them the Engine container
+  # will fail to start with `libcuda.so.1: cannot open shared object file`.
+  NVIDIA_VISIBLE_DEVICES: all
+  NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
 services:
   # The speech API service.

--- a/docker/docker-compose.aura-2.yml
+++ b/docker/docker-compose.aura-2.yml
@@ -5,6 +5,11 @@ x-env-vars: &env
   # Be sure to use the &env anchor inside an 'environment' mapping for a given service
   DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
   DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "docker-compose"
+  # Required for the Engine container to access the GPU. The nvidia-container-runtime
+  # only injects CUDA libraries when these are set; without them the Engine container
+  # will fail to start with `libcuda.so.1: cannot open shared object file`.
+  NVIDIA_VISIBLE_DEVICES: all
+  NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
 services:
   # The speech API service.

--- a/docker/docker-compose.license-proxy.yml
+++ b/docker/docker-compose.license-proxy.yml
@@ -5,6 +5,11 @@ x-env: &env
     # Make sure you `export` your self-hosted API key secret in your local environment
     DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
     DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "docker-compose"
+    # Required for the Engine container to access the GPU. The nvidia-container-runtime
+    # only injects CUDA libraries when these are set; without them the Engine container
+    # will fail to start with `libcuda.so.1: cannot open shared object file`.
+    NVIDIA_VISIBLE_DEVICES: all
+    NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
 services:
   # The speech API service.

--- a/docker/docker-compose.standard.yml
+++ b/docker/docker-compose.standard.yml
@@ -5,6 +5,11 @@ x-env: &env
     # Make sure you `export` your self-hosted API key secret in your local environment
     DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
     DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "docker-compose"
+    # Required for the Engine container to access the GPU. The nvidia-container-runtime
+    # only injects CUDA libraries when these are set; without them the Engine container
+    # will fail to start with `libcuda.so.1: cannot open shared object file`.
+    NVIDIA_VISIBLE_DEVICES: all
+    NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
 services:
   # The speech API service.

--- a/podman/podman-compose.aura-2.yml
+++ b/podman/podman-compose.aura-2.yml
@@ -17,6 +17,11 @@ services:
     environment:
       DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
       DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "podman-compose"
+      # Required for the Engine container to access the GPU. The nvidia-container-runtime
+      # only injects CUDA libraries when these are set; without them the Engine container
+      # will fail to start with `libcuda.so.1: cannot open shared object file`.
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
     # The path on the left of the colon ':' should point to files/directories on the host machine.
     # The path on the right of the colon ':' is an in-container path. It must match the path
@@ -46,6 +51,11 @@ services:
     environment:
       DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
       DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "podman-compose"
+      # Required for the Engine container to access the GPU. The nvidia-container-runtime
+      # only injects CUDA libraries when these are set; without them the Engine container
+      # will fail to start with `libcuda.so.1: cannot open shared object file`.
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
     # The path on the left of the colon ':' should point to files/directories on the host machine.
     # The path on the right of the colon ':' is an in-container path. It must match the path
@@ -77,6 +87,11 @@ services:
     environment:
       DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
       DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "podman-compose"
+      # Required for the Engine container to access the GPU. The nvidia-container-runtime
+      # only injects CUDA libraries when these are set; without them the Engine container
+      # will fail to start with `libcuda.so.1: cannot open shared object file`.
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
       IMPELLER_AURA2_MAX_BATCH_SIZE: 8
       IMPELLER_AURA2_T2C_UUID: "0ec06c9b-0aa0-44d0-a001-3ec57d32229e"
       IMPELLER_AURA2_C2A_UUID: "2e5096c7-7bf1-435e-bbdd-f673f88d0ebd"
@@ -113,6 +128,11 @@ services:
     environment:
       DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
       DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "podman-compose"
+      # Required for the Engine container to access the GPU. The nvidia-container-runtime
+      # only injects CUDA libraries when these are set; without them the Engine container
+      # will fail to start with `libcuda.so.1: cannot open shared object file`.
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
       IMPELLER_AURA2_MAX_BATCH_SIZE: 8
       IMPELLER_AURA2_T2C_UUID: "c053c7a8-7317-4de8-8a50-7e01c54e7ba9"
       IMPELLER_AURA2_C2A_UUID: "04355c1e-8148-478d-9f6c-6a6c54ec3591"
@@ -148,6 +168,11 @@ services:
     environment:
       DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
       DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "podman-compose"
+      # Required for the Engine container to access the GPU. The nvidia-container-runtime
+      # only injects CUDA libraries when these are set; without them the Engine container
+      # will fail to start with `libcuda.so.1: cannot open shared object file`.
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
     # The path on the left of the colon ':' should point to files/directories on the host machine.
     # The path on the right of the colon ':' is an in-container path. It must match the path

--- a/podman/podman-compose.license-proxy.yml
+++ b/podman/podman-compose.license-proxy.yml
@@ -16,6 +16,11 @@ services:
     environment:
       DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
       DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "podman-compose"
+      # Required for the Engine container to access the GPU. The nvidia-container-runtime
+      # only injects CUDA libraries when these are set; without them the Engine container
+      # will fail to start with `libcuda.so.1: cannot open shared object file`.
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
     # The path on the left of the colon ':' should point to files/directories on the host machine.
     # The path on the right of the colon ':' is an in-container path. It must match the path
@@ -46,6 +51,11 @@ services:
     environment:
       DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
       DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "podman-compose"
+      # Required for the Engine container to access the GPU. The nvidia-container-runtime
+      # only injects CUDA libraries when these are set; without them the Engine container
+      # will fail to start with `libcuda.so.1: cannot open shared object file`.
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
     # The path on the left of the colon ':' should point to files/directories on the host machine.
     # The path on the right of the colon ':' is an in-container path.
@@ -77,6 +87,11 @@ services:
     environment:
       DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
       DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "podman-compose"
+      # Required for the Engine container to access the GPU. The nvidia-container-runtime
+      # only injects CUDA libraries when these are set; without them the Engine container
+      # will fail to start with `libcuda.so.1: cannot open shared object file`.
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
     # The path on the left of the colon ':' should point to files/directories on the host machine.
     # The path on the right of the colon ':' is an in-container path. It must match the path

--- a/podman/podman-compose.standard.yml
+++ b/podman/podman-compose.standard.yml
@@ -16,6 +16,11 @@ services:
     environment:
       DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
       DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "podman-compose"
+      # Required for the Engine container to access the GPU. The nvidia-container-runtime
+      # only injects CUDA libraries when these are set; without them the Engine container
+      # will fail to start with `libcuda.so.1: cannot open shared object file`.
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
     # The path on the left of the colon ':' should point to files/directories on the host machine.
     # The path on the right of the colon ':' is an in-container path. It must match the path
@@ -42,6 +47,11 @@ services:
     environment:
       DEEPGRAM_API_KEY: "${DEEPGRAM_API_KEY}"
       DEEPGRAM_DEPLOYMENT_ORCHESTRATOR: "podman-compose"
+      # Required for the Engine container to access the GPU. The nvidia-container-runtime
+      # only injects CUDA libraries when these are set; without them the Engine container
+      # will fail to start with `libcuda.so.1: cannot open shared object file`.
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
 
     # The path on the left of the colon ':' should point to files/directories on the host machine.
     # The path on the right of the colon ':' is an in-container path.


### PR DESCRIPTION
## Proposed changes
This PR re-adds the GPU configuration variables that are necessary to work with the newly refactored Impeller Docker container.

## Types of changes

What types of changes does your code introduce to the Deepgram self-hosted resources?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
  - These variables were used in tests for both the `260430` self-hosted release and the refactored Docker container.  All E2E tests passed in both configurations.
- [x] I have added necessary documentation (if appropriate)

## Further comments

These changes are necessary, due to a significant structural refactor of the Docker container.  The refactor was required in service of the Blackwell support upgrade to correct issues caused by misaligned Torch/CUDA versions.  These version misalignments caused a series of crashes, memory leaks, and latency increases in production environments.