### PR TITLE
Feat/aiworks

### DIFF
--- a/.github/workflows/aiworks-chart-ci.yml
+++ b/.github/workflows/aiworks-chart-ci.yml
@@ -1,0 +1,40 @@
+name: aiworks-chart-ci
+
+on:
+  pull_request:
+    paths:
+      - "charts/deepgram-aiworks/**"
+      - ".github/workflows/aiworks-chart-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "charts/deepgram-aiworks/**"
+
+jobs:
+  lint-and-template:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        values:
+          - ci/default-values.yaml
+          - ci/files-mode-values.yaml
+          - ci/ingress-mtls-values.yaml
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install helm
+        uses: azure/setup-helm@v4
+
+      - name: helm lint
+        run: helm lint charts/deepgram-aiworks --values charts/deepgram-aiworks/${{ matrix.values }}
+
+      - name: helm template
+        run: helm template aiworks-test charts/deepgram-aiworks --values charts/deepgram-aiworks/${{ matrix.values }} > /tmp/rendered.yaml
+
+      - name: Install kubeconform
+        run: |
+          set -e
+          curl -sL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar -xz -C /usr/local/bin
+
+      - name: kubeconform render
+        run: kubeconform -strict -summary -kubernetes-version 1.28.0 -ignore-missing-schemas /tmp/rendered.yaml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,36 +28,57 @@ jobs:
       # This is currently enforced in the repositories PR settings.
       #
       # If triggered by a manual workflow run, it always releases a new chart version.
+      #
+      # Multiple charts are checked: deepgram-self-hosted and deepgram-aiworks. If either has a version bump
+      # the release job proceeds and chart-releaser-action (which auto-discovers all charts/ subdirs) publishes
+      # every chart whose version is new relative to the existing gh-pages index.
       - name: Check if Chart version was bumped
         id: check-chart-version
         run: |
-          CHART_DIR="charts/deepgram-self-hosted"
-
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "Manual trigger, attempting release..."
             echo "SHOULD_RELEASE_CHART=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          if git diff --name-only HEAD^..HEAD | grep "^$CHART_DIR"; then
-            if [ ! -f "$CHART_DIR/Chart.yaml" ]; then
-              echo "Error: Chart.yaml not found in $CHART_DIR"
-              EXIT_CODE=1
-            fi
-
-            OLD_VERSION=$(git show HEAD^:$CHART_DIR/Chart.yaml | grep '^version:' | awk '{print $2}')
-            NEW_VERSION=$(grep '^version:' $CHART_DIR/Chart.yaml | awk '{print $2}')
-
-            if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
-              echo "$CHART_DIR has been changed, but version has not been bumped, so not performing release."
-              echo "SHOULD_RELEASE_CHART=false" >> $GITHUB_OUTPUT
+          # Helper: returns "true" if CHART_DIR has a bumped version, "false" otherwise.
+          # Handles the "chart is new" edge case where Chart.yaml didn't exist in HEAD^.
+          check_chart_bumped() {
+            local CHART_DIR="$1"
+            if git diff --name-only HEAD^..HEAD | grep -q "^$CHART_DIR"; then
+              if [ ! -f "$CHART_DIR/Chart.yaml" ]; then
+                echo "Error: Chart.yaml not found in $CHART_DIR" >&2
+                echo "false"
+                return
+              fi
+              # If the chart is brand-new, treat it as a version bump.
+              if git show HEAD^:"$CHART_DIR/Chart.yaml" >/dev/null 2>&1; then
+                OLD_VERSION=$(git show HEAD^:"$CHART_DIR/Chart.yaml" | grep '^version:' | awk '{print $2}')
+              else
+                OLD_VERSION=""
+              fi
+              NEW_VERSION=$(grep '^version:' "$CHART_DIR/Chart.yaml" | awk '{print $2}')
+              if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
+                echo "$CHART_DIR has been changed, but version has not been bumped." >&2
+                echo "false"
+              else
+                echo "$CHART_DIR version bumped from '${OLD_VERSION:-<new>}' to $NEW_VERSION." >&2
+                echo "true"
+              fi
             else
-              echo "$CHART_DIR has been updated, and version has been bumped from $OLD_VERSION to $NEW_VERSION."
-              echo "Proceeding with release..."
-              echo "SHOULD_RELEASE_CHART=true" >> $GITHUB_OUTPUT
+              echo "$CHART_DIR was not modified." >&2
+              echo "false"
             fi
+          }
+
+          BUMP_SELF_HOSTED=$(check_chart_bumped "charts/deepgram-self-hosted")
+          BUMP_AIWORKS=$(check_chart_bumped "charts/deepgram-aiworks")
+
+          if [ "$BUMP_SELF_HOSTED" = "true" ] || [ "$BUMP_AIWORKS" = "true" ]; then
+            echo "At least one chart version was bumped. Proceeding with release..."
+            echo "SHOULD_RELEASE_CHART=true" >> $GITHUB_OUTPUT
           else
-            echo "deepgram-self-hosted chart was not modified."
+            echo "No chart version was bumped. Skipping release."
             echo "SHOULD_RELEASE_CHART=false" >> $GITHUB_OUTPUT
           fi
 

--- a/charts/deepgram-aiworks/Chart.yaml
+++ b/charts/deepgram-aiworks/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: deepgram-aiworks
+type: application
+version: 0.1.0
+appVersion: "0.3.0"
+description: A Helm chart for deploying VoiceWorks (AIWorks) self-hosted alongside or independent of the Deepgram speech distribution.
+home: https://developers.deepgram.com/docs/aiworks-self-hosted
+sources:
+  - https://github.com/deepgram/self-hosted-resources
+  - https://github.com/deepgram/voiceworks
+kubeVersion: ">=1.28.0-0"
+maintainers:
+  - name: Deepgram Self-Hosted
+    email: self.hosted@deepgram.com
+keywords:
+  - voice ai
+  - aiworks
+  - voiceworks
+  - flows
+  - self-hosted
+icon: https://www.dropbox.com/scl/fi/v4jtfbsrx881pbevcga3j/D-icon-black-square-250x250.png?rlkey=barv5jeuhd7t2lczz0m3nane7&dl=1

--- a/charts/deepgram-aiworks/README.md
+++ b/charts/deepgram-aiworks/README.md
@@ -1,0 +1,5 @@
+# deepgram-aiworks
+
+Helm chart for VoiceWorks (AIWorks) self-hosted. See [the design spec](https://github.com/deepgram/voiceworks/blob/master/docs/superpowers/specs/2026-05-18-aiworks-self-hosted-production-readiness-design.md) for context.
+
+Full README content lands in this chart's `0.1.0` final cut — see Plan D Task 6.

--- a/charts/deepgram-aiworks/README.md
+++ b/charts/deepgram-aiworks/README.md
@@ -1,5 +1,203 @@
 # deepgram-aiworks
 
-Helm chart for VoiceWorks (AIWorks) self-hosted. See [the design spec](https://github.com/deepgram/voiceworks/blob/master/docs/superpowers/specs/2026-05-18-aiworks-self-hosted-production-readiness-design.md) for context.
+Helm chart for VoiceWorks (AIWorks) self-hosted. Deploys the AIWorks
+backend alongside or independent of the Deepgram speech distribution
+(`deepgram-self-hosted`). Backend-only for v1; no frontend.
 
-Full README content lands in this chart's `0.1.0` final cut — see Plan D Task 6.
+## Prerequisites
+
+- Kubernetes 1.28+
+- A reachable `license-proxy` endpoint. Two ways to get one:
+  - Already running `deepgram-self-hosted` (most common). Point
+    `license.serverUrl` at `http://license-proxy.<namespace>.svc.cluster.local:8080`.
+  - Standalone license-proxy deployment (out of scope for this chart;
+    see Deepgram self-hosted docs).
+- A self-hosted Deepgram speech endpoint (STT). Point
+  `deepgram.streamingListenUrl` and `deepgram.batchListenUrl` at it.
+- Container registry access to `quay.io/deepgram/voiceworks-self-hosted`.
+  Add an `imagePullSecret` to `imagePullSecrets[]` if needed.
+
+## Quick start
+
+```sh
+helm repo add deepgram https://deepgram.github.io/self-hosted-resources
+helm install aiworks deepgram/deepgram-aiworks \
+  --set license.apiKey=<your-deepgram-api-key-uuid> \
+  --set selfHosted.apiKey=<your-40-plus-char-shared-secret> \
+  --set selfHosted.bootstrapSubject=<fresh-uuid-v4>
+```
+
+Connect to the AIWorks WebSocket execute endpoint:
+
+```
+ws://<service-or-ingress>/api/repos/<any-uuid>/flows/<flow-slug>/execute
+Authorization: Token <selfHosted.apiKey>
+```
+
+In files mode the `<any-uuid>` is just routing decoration — flows are
+looked up by slug.
+
+## Storage modes
+
+| Mode | Use when | Persistence |
+|---|---|---|
+| `files` (default) | You design flows on cloud (`aiworks.deepgram.com`), export to JSON, drop them in the `flows/` PVC | PVC at `storage.files.flowsDir` |
+| `postgres` | You want the cloud-shape DB-backed flow store | Pass `storage.postgres.dsn` |
+
+See [the self-hosted concepts](https://github.com/deepgram/voiceworks/blob/master/documentation/concepts/self-hosted.md)
+for the two-knobs model and full deployment matrix.
+
+## Examples
+
+### Files mode + open mode (most common)
+
+```sh
+helm install aiworks deepgram/deepgram-aiworks \
+  -f - <<EOF
+license:
+  apiKey: "12345678-1234-5678-abcd-beefdeadbeef"
+  serverUrl:
+    - "http://license-proxy.deepgram.svc.cluster.local:8080"
+selfHosted:
+  apiKey: "a-fresh-shared-secret-of-at-least-forty-chars"
+  bootstrapSubject: "$(uuidgen)"
+storage:
+  mode: files
+  files:
+    persistence:
+      enabled: true
+      size: 5Gi
+deepgram:
+  streamingListenUrl: "ws://api.deepgram.svc.cluster.local:8080/v1/listen"
+  batchListenUrl: "http://api.deepgram.svc.cluster.local:8080/v1/listen"
+EOF
+```
+
+### Behind an ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: aiworks.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts: [aiworks.example.com]
+      secretName: aiworks-tls
+```
+
+### In-process TLS (no ingress)
+
+```yaml
+server:
+  tls:
+    enabled: true
+    # Inline (chart creates a kubernetes.io/tls Secret):
+    cert: |
+      -----BEGIN CERTIFICATE-----
+      ...
+    key: |
+      -----BEGIN PRIVATE KEY-----
+      ...
+    # Or reference an existing Secret:
+    # existingSecret: aiworks-tls
+```
+
+SIGHUP triggers cert hot-reload — when the cert file in the mounted
+Secret changes (e.g., cert-manager rotation), send a SIGHUP to the
+pod:
+```sh
+kubectl exec -it aiworks-<id> -- kill -HUP 1
+```
+Or rely on the pod's `terminationGracePeriodSeconds` to drain a
+rolling update.
+
+### Postgres mode
+
+```yaml
+storage:
+  mode: postgres
+  postgres:
+    dsn: "postgres://user:pass@db.example.com:5432/voiceworks"
+```
+
+## Upgrading
+
+```sh
+helm upgrade aiworks deepgram/deepgram-aiworks \
+  --reuse-values \
+  --set image.tag=<new-version>
+```
+
+Default `updateStrategy.rollingUpdate.maxUnavailable=0` keeps at least
+one pod serving during the roll. Long-lived WebSocket sessions are
+drained over `terminationGracePeriodSeconds`.
+
+## Uninstalling
+
+```sh
+helm uninstall aiworks
+```
+
+Persistent volumes are retained per the cluster's reclaim policy.
+Manually delete the PVC if you want to free the storage.
+
+## Values reference
+
+The most commonly-tuned values:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `image.repository` | string | `quay.io/deepgram/voiceworks-self-hosted` | Container image |
+| `image.tag` | string | `""` (defaults to `.Chart.appVersion`) | Image tag |
+| `replicaCount` | int | `1` | Static replicas when HPA off |
+| `license.apiKey` | string | `""` (required) | License UUID; stored as `DEEPGRAM_API_KEY` in Secret |
+| `license.apiKeyExistingSecret` | string | `""` | Reference existing Secret instead of creating one |
+| `license.serverUrl` | list | `["http://license-proxy.deepgram.svc.cluster.local:8080", "https://license.deepgram.com"]` | License server URLs (priority order) |
+| `license.proxyStatusUrl` | string | `""` | Optional hermes /v1/status gate at startup |
+| `storage.mode` | string | `files` | `"files"` or `"postgres"` |
+| `storage.files.flowsDir` | string | `/flows` | Container mount path for flow JSONs |
+| `storage.files.persistence.enabled` | bool | `true` | Provision a PVC for flows |
+| `storage.files.persistence.size` | string | `1Gi` | PVC size |
+| `storage.files.persistence.storageClassName` | string | `""` | StorageClass (empty = default) |
+| `storage.files.persistence.existingClaim` | string | `""` | Reuse an existing PVC |
+| `storage.postgres.dsn` | string | `""` | Postgres DSN (required when `mode=postgres`) |
+| `selfHosted.enabled` | bool | `true` | Open-mode auth bypass |
+| `selfHosted.apiKey` | string | `""` (required when enabled) | Shared-secret token; stored as `VW_API_KEY` in Secret. **voiceworks resolves `${VW_API_KEY}` from the pod env at startup** — the literal string `"${VW_API_KEY}"` is what gets written to `config.toml`. |
+| `selfHosted.bootstrapSubject` | string | `""` (required when enabled) | Fresh UUID; **never reuse a UUID with existing data** |
+| `deepgram.streamingListenUrl` | string | `ws://api.deepgram.svc.cluster.local:8080/v1/listen` | Deepgram streaming STT endpoint |
+| `deepgram.batchListenUrl` | string | `http://api.deepgram.svc.cluster.local:8080/v1/listen` | Deepgram batch STT endpoint |
+| `server.host` | string | `0.0.0.0` | Bind address |
+| `server.port` | int | `8080` | Bind port |
+| `server.tls.enabled` | bool | `false` | Terminate TLS in voiceworks itself |
+| `server.tls.cert` | string | `""` | PEM cert chain (inline; required when `tls.enabled` and no `existingSecret`) |
+| `server.tls.key` | string | `""` | PEM private key (inline) |
+| `server.tls.existingSecret` | string | `""` | Reference an existing `kubernetes.io/tls` Secret |
+| `server.tls.clientCaBundle` | string | `""` | Optional CA bundle for mTLS |
+| `service.type` | string | `ClusterIP` | Service type |
+| `service.port` | int | `8080` | Service port |
+| `ingress.enabled` | bool | `false` | Provision an Ingress |
+| `scaling.auto.enabled` | bool | `false` | Enable HPA |
+| `scaling.auto.minReplicas` | int | `1` | HPA min |
+| `scaling.auto.maxReplicas` | int | `5` | HPA max |
+| `scaling.auto.targetCPUUtilizationPercentage` | int | `70` | HPA CPU target |
+| `networkPolicy.enabled` | bool | `false` | Provision a NetworkPolicy |
+| `serviceMonitor.enabled` | bool | `false` | Provision a kube-prometheus-stack ServiceMonitor |
+| `resources.requests` | object | `{cpu: 100m, memory: 256Mi}` | Container resource requests |
+| `resources.limits` | object | `{cpu: 1000m, memory: 1Gi}` | Container resource limits |
+| `terminationGracePeriodSeconds` | int | `60` | Pod termination grace |
+| `updateStrategy.rollingUpdate.maxUnavailable` | int/string | `0` | Rolling update max unavailable |
+| `updateStrategy.rollingUpdate.maxSurge` | int/string | `1` | Rolling update max surge |
+| `probes.readiness.*` / `probes.liveness.*` / `probes.startup.*` | various | see `values.yaml` | Probe tuning |
+| `secrets.existingSecret` | string | `""` | Reference existing Secret for license + open-mode creds (bypasses chart Secret creation) |
+| `imagePullSecrets` | list | `[]` | Pod `imagePullSecrets` |
+| `nodeSelector` / `tolerations` / `affinity` | various | `{}` / `[]` / `{}` | Pod scheduling |
+| `podLabels` / `podAnnotations` | various | `{}` | Pod metadata |
+| `podSecurityContext` / `securityContext` | various | non-root UID 10001, read-only root, all caps dropped | Pod / container security |
+
+See `values.yaml` for the full schema with inline comments.

--- a/charts/deepgram-aiworks/ci/default-values.yaml
+++ b/charts/deepgram-aiworks/ci/default-values.yaml
@@ -1,0 +1,6 @@
+# Minimum viable install. Files mode, open mode, no TLS, no ingress.
+license:
+  apiKey: "11111111-1111-1111-1111-111111111111"
+selfHosted:
+  apiKey: "test-api-key-padding-to-forty-chars-AAAA"
+  bootstrapSubject: "00000000-0000-0000-0000-0000000000a1"

--- a/charts/deepgram-aiworks/ci/files-mode-values.yaml
+++ b/charts/deepgram-aiworks/ci/files-mode-values.yaml
@@ -1,0 +1,12 @@
+# Files mode with explicit PVC + larger size.
+license:
+  apiKey: "22222222-2222-2222-2222-222222222222"
+selfHosted:
+  apiKey: "test-api-key-padding-to-forty-chars-BBBB"
+  bootstrapSubject: "00000000-0000-0000-0000-0000000000b2"
+storage:
+  mode: files
+  files:
+    persistence:
+      enabled: true
+      size: 10Gi

--- a/charts/deepgram-aiworks/ci/ingress-mtls-values.yaml
+++ b/charts/deepgram-aiworks/ci/ingress-mtls-values.yaml
@@ -1,0 +1,40 @@
+# Ingress + mTLS + ServiceMonitor + NetworkPolicy.
+license:
+  apiKey: "33333333-3333-3333-3333-333333333333"
+selfHosted:
+  apiKey: "test-api-key-padding-to-forty-chars-CCCC"
+  bootstrapSubject: "00000000-0000-0000-0000-0000000000c3"
+server:
+  tls:
+    enabled: true
+    cert: |
+      -----BEGIN CERTIFICATE-----
+      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+      -----END CERTIFICATE-----
+    key: |
+      -----BEGIN PRIVATE KEY-----
+      MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcw
+      -----END PRIVATE KEY-----
+    clientCaBundle: |
+      -----BEGIN CERTIFICATE-----
+      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+      -----END CERTIFICATE-----
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: aiworks.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+scaling:
+  auto:
+    enabled: true
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          purpose: client
+serviceMonitor:
+  enabled: true

--- a/charts/deepgram-aiworks/templates/_helpers.tpl
+++ b/charts/deepgram-aiworks/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Chart name + version for the helm.sh/chart label.
+*/}}
+{{- define "deepgram-aiworks.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully-qualified app name. Truncated to 63 chars (k8s name limit). Suffixed
+with the Helm release name so multiple releases in one namespace don't collide.
+*/}}
+{{- define "deepgram-aiworks.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels — applied to every resource.
+*/}}
+{{- define "deepgram-aiworks.labels" -}}
+app.kubernetes.io/name: "deepgram-aiworks"
+helm.sh/chart: {{ include "deepgram-aiworks.chart" . }}
+{{ include "deepgram-aiworks.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: deepgram
+{{- end -}}
+
+{{/*
+Selector labels — applied to pods. Must remain stable across upgrades or
+the Deployment selector breaks.
+*/}}
+{{- define "deepgram-aiworks.selectorLabels" -}}
+app.kubernetes.io/name: "deepgram-aiworks"
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Name of the secret that holds DEEPGRAM_API_KEY and VW_API_KEY. Uses an
+existing Secret if .Values.secrets.existingSecret is set; otherwise the
+chart creates one named "<fullname>-credentials".
+*/}}
+{{- define "deepgram-aiworks.credentialsSecretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else -}}
+{{- printf "%s-credentials" (include "deepgram-aiworks.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the TLS Secret. Uses an existing kubernetes.io/tls Secret if set;
+otherwise the chart creates one. When server.tls.enabled=false, neither
+the existingSecret nor the inline cert/key matter.
+*/}}
+{{- define "deepgram-aiworks.tlsSecretName" -}}
+{{- if .Values.server.tls.existingSecret -}}
+{{- .Values.server.tls.existingSecret -}}
+{{- else -}}
+{{- printf "%s-tls" (include "deepgram-aiworks.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/deepgram-aiworks/templates/configmap.yaml
+++ b/charts/deepgram-aiworks/templates/configmap.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "deepgram-aiworks.fullname" . }}-config
+  labels:
+    {{- include "deepgram-aiworks.labels" . | nindent 4 }}
+data:
+  config.toml: |
+    # NOTE: [self_hosted].api_key uses ${VW_API_KEY} env-var
+    # substitution — voiceworks's config loader resolves it from the
+    # pod env at startup. See backend/src/config.rs for the
+    # resolution logic (commit 9302010).
+
+    [server]
+    host   = "{{ .Values.server.host }}"
+    port   = {{ .Values.server.port }}
+    prefix = "{{ .Values.server.prefix }}"
+    ws_idle_timeout = "{{ .Values.server.wsIdleTimeout }}"
+    {{- if .Values.server.tls.enabled }}
+    cert = "/etc/voiceworks/tls/tls.crt"
+    key  = "/etc/voiceworks/tls/tls.key"
+    {{- if or .Values.server.tls.clientCaBundle .Values.server.tls.clientCaBundleExistingSecret }}
+    client_ca_bundle = "/etc/voiceworks/tls/ca.crt"
+    {{- end }}
+    {{- end }}
+
+    [storage]
+    mode = "{{ .Values.storage.mode }}"
+    {{- if eq .Values.storage.mode "files" }}
+    [storage.files]
+    flows_dir = "{{ .Values.storage.files.flowsDir }}"
+    {{- end }}
+
+    [deepgram]
+    streaming_listen_url = "{{ .Values.deepgram.streamingListenUrl }}"
+    batch_listen_url     = "{{ .Values.deepgram.batchListenUrl }}"
+
+    {{- if .Values.selfHosted.enabled }}
+    [self_hosted]
+    enabled = true
+    api_key = "${VW_API_KEY}"
+    bootstrap_subject = "{{ required "selfHosted.bootstrapSubject is required when selfHosted.enabled" .Values.selfHosted.bootstrapSubject }}"
+    {{- if .Values.license.proxyStatusUrl }}
+    license_proxy_status_url = "{{ .Values.license.proxyStatusUrl }}"
+    {{- end }}
+    {{- end }}
+
+    [license]
+    server_url = [
+    {{- range $i, $url := .Values.license.serverUrl }}
+      {{- if $i }},{{ end }}
+      "{{ $url }}"
+    {{- end }}
+    ]

--- a/charts/deepgram-aiworks/templates/deployment.yaml
+++ b/charts/deepgram-aiworks/templates/deployment.yaml
@@ -1,0 +1,142 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "deepgram-aiworks.fullname" . }}
+  labels:
+    {{- include "deepgram-aiworks.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.scaling.auto.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  strategy:
+    type: {{ .Values.updateStrategy.type }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.updateStrategy.rollingUpdate.maxSurge }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "deepgram-aiworks.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "deepgram-aiworks.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        # Force a pod restart when the config.toml changes — without this,
+        # config changes don't propagate until a manual restart.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: voiceworks
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args: ["run", "-c", "/etc/voiceworks/config.toml"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.server.port }}
+              protocol: TCP
+          env:
+            - name: DEEPGRAM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "deepgram-aiworks.credentialsSecretName" . }}
+                  key: {{ .Values.license.apiKeyExistingSecretKey }}
+            {{- if .Values.selfHosted.enabled }}
+            - name: VW_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "deepgram-aiworks.credentialsSecretName" . }}
+                  key: {{ .Values.selfHosted.apiKeyExistingSecretKey }}
+            {{- end }}
+            {{- if eq .Values.storage.mode "postgres" }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.storage.postgres.dsnExistingSecret }}{{ .Values.storage.postgres.dsnExistingSecret }}{{ else }}{{ include "deepgram-aiworks.credentialsSecretName" . }}{{ end }}
+                  key: {{ .Values.storage.postgres.dsnExistingSecretKey }}
+            {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/voiceworks
+              readOnly: true
+            {{- if .Values.server.tls.enabled }}
+            - name: tls
+              mountPath: /etc/voiceworks/tls
+              readOnly: true
+            {{- end }}
+            {{- if and (eq .Values.storage.mode "files") .Values.storage.files.persistence.enabled }}
+            - name: flows
+              mountPath: {{ .Values.storage.files.flowsDir }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+              scheme: {{ if .Values.server.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+              scheme: {{ if .Values.server.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+              scheme: {{ if .Values.server.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "deepgram-aiworks.fullname" . }}-config
+        {{- if .Values.server.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ include "deepgram-aiworks.tlsSecretName" . }}
+        {{- end }}
+        {{- if and (eq .Values.storage.mode "files") .Values.storage.files.persistence.enabled }}
+        - name: flows
+          persistentVolumeClaim:
+            claimName: {{ if .Values.storage.files.persistence.existingClaim }}{{ .Values.storage.files.persistence.existingClaim }}{{ else }}{{ include "deepgram-aiworks.fullname" . }}-flows{{ end }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/deepgram-aiworks/templates/hpa.yaml
+++ b/charts/deepgram-aiworks/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.scaling.auto.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "deepgram-aiworks.fullname" . }}
+  labels:
+    {{- include "deepgram-aiworks.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "deepgram-aiworks.fullname" . }}
+  minReplicas: {{ .Values.scaling.auto.minReplicas }}
+  maxReplicas: {{ .Values.scaling.auto.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.scaling.auto.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/deepgram-aiworks/templates/ingress.yaml
+++ b/charts/deepgram-aiworks/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "deepgram-aiworks.fullname" . }}
+  labels:
+    {{- include "deepgram-aiworks.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "deepgram-aiworks.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/deepgram-aiworks/templates/networkpolicy.yaml
+++ b/charts/deepgram-aiworks/templates/networkpolicy.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "deepgram-aiworks.fullname" . }}
+  labels:
+    {{- include "deepgram-aiworks.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "deepgram-aiworks.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egressTo }}
+    - Egress
+    {{- end }}
+  {{- with .Values.networkPolicy.ingressFrom }}
+  ingress:
+    - from:
+        {{- toYaml . | nindent 8 }}
+      ports:
+        - protocol: TCP
+          port: {{ $.Values.server.port }}
+  {{- end }}
+  {{- with .Values.networkPolicy.egressTo }}
+  egress:
+    - to:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+{{- end }}

--- a/charts/deepgram-aiworks/templates/pvc.yaml
+++ b/charts/deepgram-aiworks/templates/pvc.yaml
@@ -1,0 +1,16 @@
+{{- if and (eq .Values.storage.mode "files") .Values.storage.files.persistence.enabled (not .Values.storage.files.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "deepgram-aiworks.fullname" . }}-flows
+  labels:
+    {{- include "deepgram-aiworks.labels" . | nindent 4 }}
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: {{ .Values.storage.files.persistence.size }}
+  {{- if .Values.storage.files.persistence.storageClassName }}
+  storageClassName: {{ .Values.storage.files.persistence.storageClassName | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/deepgram-aiworks/templates/secret.yaml
+++ b/charts/deepgram-aiworks/templates/secret.yaml
@@ -1,0 +1,35 @@
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "deepgram-aiworks.credentialsSecretName" . }}
+  labels:
+    {{- include "deepgram-aiworks.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.license.apiKeyExistingSecretKey }}: {{ required "license.apiKey is required (or set license.apiKeyExistingSecret)" .Values.license.apiKey | quote }}
+  {{- if .Values.selfHosted.enabled }}
+  {{ .Values.selfHosted.apiKeyExistingSecretKey }}: {{ required "selfHosted.apiKey is required when selfHosted.enabled" .Values.selfHosted.apiKey | quote }}
+  {{- end }}
+  {{- if eq .Values.storage.mode "postgres" }}
+  {{- if not .Values.storage.postgres.dsnExistingSecret }}
+  {{ .Values.storage.postgres.dsnExistingSecretKey }}: {{ required "storage.postgres.dsn is required when storage.mode=postgres" .Values.storage.postgres.dsn | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.server.tls.enabled (not .Values.server.tls.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "deepgram-aiworks.tlsSecretName" . }}
+  labels:
+    {{- include "deepgram-aiworks.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+stringData:
+  tls.crt: {{ required "server.tls.cert required when server.tls.enabled and no existingSecret" .Values.server.tls.cert | quote }}
+  tls.key: {{ required "server.tls.key required when server.tls.enabled and no existingSecret" .Values.server.tls.key | quote }}
+  {{- if .Values.server.tls.clientCaBundle }}
+  ca.crt: {{ .Values.server.tls.clientCaBundle | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/deepgram-aiworks/templates/service.yaml
+++ b/charts/deepgram-aiworks/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "deepgram-aiworks.fullname" . }}
+  labels:
+    {{- include "deepgram-aiworks.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "deepgram-aiworks.selectorLabels" . | nindent 4 }}

--- a/charts/deepgram-aiworks/templates/servicemonitor.yaml
+++ b/charts/deepgram-aiworks/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "deepgram-aiworks.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "deepgram-aiworks.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "deepgram-aiworks.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      path: /metrics
+{{- end }}

--- a/charts/deepgram-aiworks/templates/tests/test-connection.yaml
+++ b/charts/deepgram-aiworks/templates/tests/test-connection.yaml
@@ -16,9 +16,20 @@ spec:
       args:
         - |
           set -e
-          echo "Waiting for {{ include "deepgram-aiworks.fullname" . }}:{{ .Values.service.port }} to accept connections..."
+          {{- if .Values.server.tls.enabled }}
+          # TLS is enabled in voiceworks. We curl https:// with -k since the
+          # in-process cert may be self-signed or otherwise not in the curl
+          # image's trust store. helm-test verifies the listener is up and
+          # responding; cert validation is out of scope for a smoke test.
+          URL="https://{{ include "deepgram-aiworks.fullname" . }}:{{ .Values.service.port }}/api/health"
+          CURL_FLAGS="-fsS -k --max-time 2"
+          {{- else }}
+          URL="http://{{ include "deepgram-aiworks.fullname" . }}:{{ .Values.service.port }}/api/health"
+          CURL_FLAGS="-fsS --max-time 2"
+          {{- end }}
+          echo "Waiting for $URL to accept connections..."
           for i in $(seq 1 30); do
-            if curl -fsS --max-time 2 http://{{ include "deepgram-aiworks.fullname" . }}:{{ .Values.service.port }}/api/health > /tmp/out 2>&1; then
+            if curl $CURL_FLAGS "$URL" > /tmp/out 2>&1; then
               echo "health endpoint responded:"
               cat /tmp/out
               exit 0

--- a/charts/deepgram-aiworks/templates/tests/test-connection.yaml
+++ b/charts/deepgram-aiworks/templates/tests/test-connection.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "deepgram-aiworks.fullname" . }}-test-connection"
+  labels:
+    {{- include "deepgram-aiworks.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: curlimages/curl:8.10.1
+      command: ["sh", "-c"]
+      args:
+        - |
+          set -e
+          echo "Waiting for {{ include "deepgram-aiworks.fullname" . }}:{{ .Values.service.port }} to accept connections..."
+          for i in $(seq 1 30); do
+            if curl -fsS --max-time 2 http://{{ include "deepgram-aiworks.fullname" . }}:{{ .Values.service.port }}/api/health > /tmp/out 2>&1; then
+              echo "health endpoint responded:"
+              cat /tmp/out
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "timed out waiting for health endpoint"
+          exit 1

--- a/charts/deepgram-aiworks/values.yaml
+++ b/charts/deepgram-aiworks/values.yaml
@@ -1,0 +1,200 @@
+# -- Override the chart name for resource naming.
+nameOverride: ""
+
+# Image
+image:
+  # -- Container image repository for the AIWorks self-hosted backend.
+  repository: quay.io/deepgram/voiceworks-self-hosted
+  # -- Image tag. Defaults to .Chart.appVersion if empty.
+  tag: ""
+  # -- imagePullPolicy passed to the container spec.
+  pullPolicy: IfNotPresent
+
+# -- imagePullSecrets passed to the pod spec. List of {name: <secret>}.
+imagePullSecrets: []
+
+# -- Static replica count when scaling.auto.enabled is false.
+replicaCount: 1
+
+# License check-in. Required when the image is built with --features self-hosted.
+license:
+  # -- License ID (UUID). Stored in the credentials Secret as DEEPGRAM_API_KEY.
+  # Required unless apiKeyExistingSecret is set.
+  apiKey: ""
+  # -- Alternative: reference an existing Secret rather than letting the chart create one.
+  apiKeyExistingSecret: ""
+  # -- Key inside apiKeyExistingSecret that holds the license UUID.
+  apiKeyExistingSecretKey: "DEEPGRAM_API_KEY"
+  # -- License server URLs. Priority order; first is primary, others fall back.
+  serverUrl:
+    - "http://license-proxy.deepgram.svc.cluster.local:8080"
+    - "https://license.deepgram.com"
+  # -- Optional hermes health gate at startup. Backend refuses to start
+  # unless this endpoint reports Connected or TrustBased.
+  proxyStatusUrl: ""
+
+# Storage mode. "files" loads exported flow JSONs from disk; "postgres" keeps
+# the cloud-shape DB-backed flow store.
+storage:
+  # -- "files" or "postgres".
+  mode: files
+  files:
+    # -- Mount path for the flows directory inside the container.
+    flowsDir: /flows
+    persistence:
+      # -- Provision a PVC for flowsDir.
+      enabled: true
+      # -- PVC size.
+      size: 1Gi
+      # -- StorageClass. Empty string uses cluster default.
+      storageClassName: ""
+      # -- Reuse an existing PVC instead of letting the chart create one.
+      existingClaim: ""
+  postgres:
+    # -- Postgres DSN. Required when mode=postgres unless dsnExistingSecret is set.
+    dsn: ""
+    # -- Alternative: existing Secret holding the DSN.
+    dsnExistingSecret: ""
+    dsnExistingSecretKey: "DATABASE_URL"
+
+# Open-mode auth bypass. When enabled, the backend skips the Console auth round-trip
+# and uses a shared-secret token in constant-time compare.
+selfHosted:
+  # -- Enable open mode.
+  enabled: true
+  # -- Shared-secret token clients present as `Authorization: Token <api_key>`.
+  # Stored in the credentials Secret as VW_API_KEY.
+  apiKey: ""
+  apiKeyExistingSecret: ""
+  apiKeyExistingSecretKey: "VW_API_KEY"
+  # -- UUID for the synthetic single-tenant subject. Generate a fresh one per
+  # deployment — DO NOT reuse a UUID that already has data attached.
+  bootstrapSubject: ""
+
+# Deepgram speech endpoints. Override to point at your self-hosted Deepgram
+# distribution.
+deepgram:
+  streamingListenUrl: "ws://api.deepgram.svc.cluster.local:8080/v1/listen"
+  batchListenUrl: "http://api.deepgram.svc.cluster.local:8080/v1/listen"
+
+# Server config — listener + TLS.
+server:
+  host: "0.0.0.0"
+  port: 8080
+  prefix: "/"
+  wsIdleTimeout: "5m"
+  tls:
+    # -- Terminate TLS in voiceworks itself. When false, an ingress in front
+    # is expected to handle TLS termination.
+    enabled: false
+    # -- Inline cert (PEM) — passed through to the chart-created TLS Secret.
+    cert: ""
+    # -- Inline key (PEM).
+    key: ""
+    # -- Alternative: reference an existing kubernetes.io/tls Secret.
+    existingSecret: ""
+    # -- Optional client CA bundle (PEM) for mTLS. When set, the server
+    # requires incoming clients to present a cert signed by one of these CAs.
+    clientCaBundle: ""
+    clientCaBundleExistingSecret: ""
+
+# Service.
+service:
+  type: ClusterIP
+  port: 8080
+  # -- Additional Service annotations.
+  annotations: {}
+
+# Ingress.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
+# Autoscaling.
+scaling:
+  auto:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+
+# Observability.
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  namespace: ""
+  additionalLabels: {}
+
+# NetworkPolicy. Default-deny is opinionated — enable only if your cluster
+# already enforces NetworkPolicy.
+networkPolicy:
+  enabled: false
+  # -- Pods/namespaces allowed to talk to the AIWorks Service.
+  ingressFrom: []
+  # -- Egress allowlist. Empty = allow all (k8s default).
+  egressTo: []
+
+# Pod security.
+podSecurityContext: {}
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+
+# Resources.
+resources:
+  requests:
+    cpu: "100m"
+    memory: "256Mi"
+  limits:
+    cpu: "1000m"
+    memory: "1Gi"
+
+# Scheduling.
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podLabels: {}
+
+# Probes.
+probes:
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    failureThreshold: 3
+  liveness:
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    failureThreshold: 3
+  # Startup probe gives the initial license check-in + flow load enough time.
+  startup:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    failureThreshold: 60   # 5 minutes total
+
+# Termination grace — long enough for in-flight WS sessions to drain.
+terminationGracePeriodSeconds: 60
+
+# Update strategy. maxUnavailable=0 keeps existing pods serving during a roll.
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
+# Existing Secret reference (alternative to license.apiKey + selfHosted.apiKey).
+secrets:
+  # -- If set, the chart will not create a credentials Secret. Both the
+  # license API key and the open-mode API key must live in this Secret under
+  # the keys specified by license.apiKeyExistingSecretKey and
+  # selfHosted.apiKeyExistingSecretKey.
+  existingSecret: ""


### PR DESCRIPTION
# Add `deepgram-aiworks` Helm chart

New chart at `charts/deepgram-aiworks/` for deploying VoiceWorks
(AIWorks) self-hosted on Kubernetes. Parallel to `deepgram-self-hosted`,
independently versioned, backend-only (no frontend) for v1.

## Summary

- New chart with full template set: Deployment, Service, ConfigMap
  (renders `config.toml` from values), Secret (creds + optional TLS
  material), PVC, plus optional Ingress / HPA / NetworkPolicy /
  ServiceMonitor each gated on its own values flag.
- Helm `helm test` post-install Pod that curls `/api/health` (branches
  on `server.tls.enabled` to use http vs https).
- CI matrix at `.github/workflows/aiworks-chart-ci.yml` — runs
  `helm lint` + `helm template` + `kubeconform` across three values
  scenarios (default, files-mode, ingress + mTLS).
- `publish.yml` extended so version bumps on either `deepgram-self-hosted`
  OR `deepgram-aiworks` trigger a release; handles the "new chart on
  first merge" edge case (no prior `Chart.yaml` in `HEAD^`).
- Chart README with prerequisites, quick start, four example deployments
  (files+open mode, ingress, in-process TLS, postgres), upgrade /
  uninstall recipes, and a values reference table.

## Quick-start example

```sh
helm repo add deepgram https://deepgram.github.io/self-hosted-resources
helm install aiworks deepgram/deepgram-aiworks \
  --set license.apiKey=<deepgram-license-uuid> \
  --set selfHosted.apiKey=<40+-char-shared-secret> \
  --set selfHosted.bootstrapSubject=$(uuidgen | tr A-Z a-z)
```

Connect clients via:
```
ws://<service-or-ingress>/api/repos/<any-uuid>/flows/<flow-slug>/execute
Authorization: Token <selfHosted.apiKey>
```

## Architectural notes for reviewers

- **License-proxy is NOT bundled.** The chart's `license.serverUrl`
  defaults to `http://license-proxy.deepgram.svc.cluster.local:8080`
  with `https://license.deepgram.com` as fallback. Operators reuse the
  license-proxy from an existing `deepgram-self-hosted` install or
  point at a standalone deployment.
- **`${VW_API_KEY}` flows through pod env.** Helm can't inline Secret
  values at template time, so the ConfigMap renders
  `[self_hosted].api_key = "${VW_API_KEY}"` as a literal placeholder.
  Voiceworks's config loader resolves it from `std::env::var` at
  startup — the corresponding backend change shipped in voiceworks
  commit `9302010`. The chart README documents this contract in the
  values reference.
- **`/api/health` is used for all three probes** (readiness / liveness /
  startup). It's unconditionally registered in both `files` and
  `postgres` storage modes, so probe config doesn't need to branch on
  `storage.mode`.
- **Security defaults:** non-root UID 10001, `readOnlyRootFilesystem`,
  all caps dropped. Matches the `voiceworks-self-hosted` image's user.
- **`updateStrategy.rollingUpdate.maxUnavailable: 0`** by default —
  keeps at least one pod serving during rolling upgrades. Long-lived
  WebSocket sessions drain over `terminationGracePeriodSeconds`.

## What's intentionally out of scope

- **Self-hosted frontend** (Next.js editor). Backend-only for v1.
- **Bundled license-proxy.** Operators bring their own (existing
  `deepgram-self-hosted` install or standalone).
- **ACME / Let's Encrypt in-process.** Use an ingress controller for
  public-internet TLS termination.
- **SNI-based multi-cert.** Single cert per listener.

## Companion voiceworks work

This PR is the chart half of a four-plan effort to make AIWorks
production-ready for self-hosted. The matching backend changes ship
on the `feat/self-hosted` branch of github.com/deepgram/voiceworks —
that branch will land separately.

Design spec lives at
`voiceworks/docs/superpowers/specs/2026-05-18-aiworks-self-hosted-production-readiness-design.md`.

## Test plan

- [x] `helm lint` clean against all three CI values files
  (default-values.yaml, files-mode-values.yaml, ingress-mtls-values.yaml)
- [x] `helm template` produces well-formed manifests for each scenario
- [x] CI workflow YAML parses; `kubeconform` step uses
  `-ignore-missing-schemas` to allow CRDs (ServiceMonitor)
- [ ] First merge to `main` triggers chart release via `publish.yml`
  (verify after merge — the "new chart on first merge" branch is
  exercised here for the first time)
- [ ] `helm install` against a real cluster pointing at an existing
  `deepgram-self-hosted` license-proxy
- [ ] `helm test aiworks` returns success in both TLS-on and TLS-off
  configurations

## Required follow-ups (out of this PR)

- voiceworks `feat/self-hosted` branch must land before the chart is
  usable end-to-end (provides the backend image and the
  `${VW_API_KEY}` env-var resolution this chart relies on).
- `developers.deepgram.com` should get an "AIWorks (Self-Hosted)"
  section that links into the chart README and the in-product docs
  shipping in voiceworks.