### PR TITLE
Adds serviceAccount.annotations support 

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+### Added
+
+- Support for configuring custom annotations on Kubernetes `ServiceAccount` resources for API, Engine, License Proxy, and Billing deployments (`api.serviceAccount.annotations`, `engine.serviceAccount.annotations`, `licenseProxy.serviceAccount.annotations`, and `billing.serviceAccount.annotations`). This allows integrating IAM Roles for Service Accounts (IRSA).
+
 ## [0.37.0] - 2026-05-28
 
 ### Added

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -303,6 +303,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | api.service.externalTrafficPolicy | string | `` | External traffic policy for LoadBalancer service. Options: Cluster, Local Only applies when service type is LoadBalancer |
 | api.service.loadBalancerSourceRanges | list | `` | List of IP CIDR ranges allowed to access the LoadBalancer service Only applies when service type is LoadBalancer |
 | api.service.type | string | `ClusterIP` | Service type for the API external service. Options: ClusterIP, NodePort, LoadBalancer |
+| api.serviceAccount.annotations | object | `{}` | Annotations to add to the API service account. |
 | api.serviceAccount.create | bool | `true` | Specifies whether to create a default service account for the Deepgram API Deployment. |
 | api.serviceAccount.name | string | `nil` | Allows providing a custom service account name for the API component. If left empty, the default service account name will be used. If specified, and `api.serviceAccount.create = true`, this defines the name of the default service account. If specified, and `api.serviceAccount.create = false`, this provides the name of a preconfigured service account you wish to attach to the API deployment. |
 | api.tolerations | list | `[]` | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to apply to API pods. |
@@ -346,6 +347,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | billing.server.certificatesPort | int | `8080` | certificatesPort is the port for the HTTP certificates endpoint (/v1/certificates). Must be set explicitly for the certificates endpoint to be reachable. |
 | billing.server.host | string | `"0.0.0.0"` | host is the IP address to listen on. You will want to listen on all interfaces to interact with other pods in the cluster. |
 | billing.server.port | int | `8443` | port to listen on. |
+| billing.serviceAccount.annotations | object | `{}` | Annotations to add to the Billing service account. |
 | billing.serviceAccount.create | bool | `true` | Specifies whether to create a default service account for the Deepgram Billing Deployment. |
 | billing.serviceAccount.name | string | `nil` | Allows providing a custom service account name for the Billing component. If left empty, the default service account name will be used. If specified, and `billing.serviceAccount.create = true`, this defines the name of the default service account. If specified, and `billing.serviceAccount.create = false`, this provides the name of a preconfigured service account you wish to attach to the Billing deployment. |
 | billing.tolerations | list | `[]` | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to apply to Billing pods. |
@@ -425,6 +427,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | engine.service.externalTrafficPolicy | string | `` | External traffic policy for LoadBalancer service. Options: Cluster, Local Only applies when service type is LoadBalancer |
 | engine.service.loadBalancerSourceRanges | list | `` | List of IP CIDR ranges allowed to access the LoadBalancer service Only applies when service type is LoadBalancer |
 | engine.service.type | string | `ClusterIP` | Service type for the Engine metrics service. Options: ClusterIP, NodePort, LoadBalancer |
+| engine.serviceAccount.annotations | object | `{}` | Annotations to add to the Engine service account. |
 | engine.serviceAccount.create | bool | `true` | Specifies whether to create a default service account for the Deepgram Engine Deployment. |
 | engine.serviceAccount.name | string | `nil` | Allows providing a custom service account name for the Engine component. If left empty, the default service account name will be used. If specified, and `engine.serviceAccount.create = true`, this defines the name of the default service account. If specified, and `engine.serviceAccount.create = false`, this provides the name of a preconfigured service account you wish to attach to the Engine deployment. |
 | engine.startupProbe | object | `` | The startupProbe combination of `periodSeconds` and `failureThreshold` allows time for the container to load all models and start listening for incoming requests.  Model load time can be affected by hardware I/O speeds, as well as network speeds if you are using a network volume mount for the models.  If you are hitting the failure threshold before models are finished loading, you may want to extend the startup probe. However, this will also extend the time it takes to detect a pod that can't establish a network connection to validate its license. |
@@ -481,6 +484,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | licenseProxy.service.externalTrafficPolicy | string | `` | External traffic policy for LoadBalancer service. Options: Cluster, Local Only applies when service type is LoadBalancer |
 | licenseProxy.service.loadBalancerSourceRanges | list | `` | List of IP CIDR ranges allowed to access the LoadBalancer service Only applies when service type is LoadBalancer |
 | licenseProxy.service.type | string | `ClusterIP` | Service type for the License Proxy status service. Options: ClusterIP, NodePort, LoadBalancer |
+| licenseProxy.serviceAccount.annotations | object | `{}` | Annotations to add to the License Proxy service account. |
 | licenseProxy.serviceAccount.create | bool | `true` | Specifies whether to create a default service account for the Deepgram License Proxy Deployment. |
 | licenseProxy.serviceAccount.name | string | `nil` | Allows providing a custom service account name for the LicenseProxy component. If left empty, the default service account name will be used. If specified, and `licenseProxy.serviceAccount.create = true`, this defines the name of the default service account. If specified, and `licenseProxy.serviceAccount.create = false`, this provides the name of a preconfigured service account you wish to attach to the License Proxy deployment. |
 | licenseProxy.tolerations | list | `[]` | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to apply to License Proxy pods. |

--- a/charts/deepgram-self-hosted/templates/api/api.rbac.yaml
+++ b/charts/deepgram-self-hosted/templates/api/api.rbac.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ default (printf "%s-sa" .Values.api.namePrefix) .Values.api.serviceAccount.name }}
+  {{- with .Values.api.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
 {{ include "deepgram-self-hosted.labels" . | indent 4}}
 ---

--- a/charts/deepgram-self-hosted/templates/billing/billing.rbac.yaml
+++ b/charts/deepgram-self-hosted/templates/billing/billing.rbac.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ default (printf "%s-sa" .Values.billing.namePrefix) .Values.billing.serviceAccount.name }}
+  {{- with .Values.billing.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
 {{ include "deepgram-self-hosted.labels" . | indent 4}}
 ---

--- a/charts/deepgram-self-hosted/templates/engine/engine.rbac.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.rbac.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ default (printf "%s-sa" .Values.engine.namePrefix) .Values.engine.serviceAccount.name }}
+  {{- with .Values.engine.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
 {{ include "deepgram-self-hosted.labels" . | indent 4}}
 ---

--- a/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.rbac.yaml
+++ b/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.rbac.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ default (printf "%s-sa" .Values.licenseProxy.namePrefix) .Values.licenseProxy.serviceAccount.name }}
+  {{- with .Values.licenseProxy.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
 {{ include "deepgram-self-hosted.labels" . | indent 4}}
 ---

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -347,6 +347,8 @@ api:
     # If specified, and `api.serviceAccount.create = false`, this provides the name of a preconfigured service account
     # you wish to attach to the API deployment.
     name:
+    # -- (object) Annotations to add to the API service account.
+    annotations: {}
 
   # -- Configure how the API will listen for your requests
   # @default -- ``
@@ -634,6 +636,8 @@ engine:
     # If specified, and `engine.serviceAccount.create = false`, this provides the name of a preconfigured service account
     # you wish to attach to the Engine deployment.
     name:
+    # -- (object) Annotations to add to the Engine service account.
+    annotations: {}
 
   concurrencyLimit:
     # -- (int) activeRequests limits the number of active requests handled by
@@ -945,6 +949,8 @@ licenseProxy:
     # If specified, and `licenseProxy.serviceAccount.create = false`, this provides the name of a preconfigured service account
     # you wish to attach to the License Proxy deployment.
     name:
+    # -- (object) Annotations to add to the License Proxy service account.
+    annotations: {}
 
   # -- Configure how the license proxy will listen for licensing requests.
   # @default -- ``
@@ -1124,6 +1130,8 @@ billing:
     # If specified, and `billing.serviceAccount.create = false`, this provides the name of a preconfigured service account
     # you wish to attach to the Billing deployment.
     name:
+    # -- (object) Annotations to add to the Billing service account.
+    annotations: {}
 
   # -- Configure how the Billing container will listen for licensing requests.
   # @default -- ``


### PR DESCRIPTION
## Proposed changes
Adds serviceAccount.annotations support to the api, engine, licenseProxy, and billing components.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes

What types of changes does your code introduce to the Deepgram self-hosted resources?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
  - Validated via helm template rendering: confirmed annotations are emitted when set and no annotations: block appears when the field is left at its default ({}). Tested all four components (api, engine, licenseProxy, billing).
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
