### PR TITLE
chore(release): bump default tags to July 2026 release (release-260714)

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## [0.40.0] - 2026-07-15
+
+### Changed
+
+- Updated default container tags to July 2026 release (`release-260714`). Refer to the [main Deepgram changelog](https://developers.deepgram.com/changelog/self-hosted-changelog#deepgram-self-hosted-july-2026-release-260714) for additional details.
+
 ## [0.39.0] - 2026-06-30
 
 ### Added
@@ -483,7 +489,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Initial implementation of the Helm chart.
 
-[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.39.0...HEAD
+[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.40.0...HEAD
+[0.40.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.39.0...deepgram-self-hosted-0.40.0
 [0.39.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.38.0...deepgram-self-hosted-0.39.0
 [0.38.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.37.0...deepgram-self-hosted-0.38.0
 [0.37.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.36.0...deepgram-self-hosted-0.37.0

--- a/charts/deepgram-self-hosted/Chart.yaml
+++ b/charts/deepgram-self-hosted/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: deepgram-self-hosted
 type: application
-version: 0.39.0
-appVersion: "release-260630"
+version: 0.40.0
+appVersion: "release-260714"
 description: A Helm chart for running Deepgram services in a self-hosted environment
 home: "https://developers.deepgram.com/docs/self-hosted-introduction"
 sources: ["https://github.com/deepgram/self-hosted-resources"]

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -1,6 +1,6 @@
 # deepgram-self-hosted
 
-![Version: 0.39.0](https://img.shields.io/badge/Version-0.39.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260630](https://img.shields.io/badge/AppVersion-release--260630-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
+![Version: 0.40.0](https://img.shields.io/badge/Version-0.40.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260714](https://img.shields.io/badge/AppVersion-release--260714-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
 
 A Helm chart for running Deepgram services in a self-hosted environment
 
@@ -282,7 +282,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | api.features.redactUsage | bool | `true` | Enables usage metadata redaction; set to false to disable redaction of usage metadata |
 | api.image.path | string | `"quay.io/deepgram/self-hosted-api"` | path configures the image path to use for creating API containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | api.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram API image |
-| api.image.tag | string | `"release-260630"` | tag defines which Deepgram release to use for API containers |
+| api.image.tag | string | `"release-260714"` | tag defines which Deepgram release to use for API containers |
 | api.livenessProbe | object | `` | Liveness probe customization for API pods. |
 | api.namePrefix | string | `"deepgram-api"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram API containers. |
 | api.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to API pods. |
@@ -330,7 +330,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | billing.extraEnv | list | `[]` | Extra environment variables for the Billing container. |
 | billing.image.path | string | `"quay.io/deepgram/self-hosted-billing"` | path configures the image path to use for creating Billing containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | billing.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram Billing image |
-| billing.image.tag | string | `"release-260630"` | tag defines which Deepgram release to use for Billing containers |
+| billing.image.tag | string | `"release-260714"` | tag defines which Deepgram release to use for Billing containers |
 | billing.journal | object | `` | Configuration for the usage journal volume. The journal tracks usage for billing purposes and must be persisted. WARNING: Do not delete or lose this volume as it contains critical billing data. Failure to persist and return journal files may result in suspension of service. |
 | billing.journal.aws | object | `` | AWS-specific volume configuration for billing journals |
 | billing.journal.aws.efs.size | string | `"1Gi"` | Size of the EFS PVC for journals. |
@@ -395,7 +395,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | engine.health.gpuRequired | bool | `false` | Engine will automatically fall back to CPU when a GPU is not detected. You can explicitly require a GPU by setting this option to true, production deployments must use a GPU for acceptable performance. |
 | engine.image.path | string | `"quay.io/deepgram/self-hosted-engine"` | path configures the image path to use for creating Engine containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | engine.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram Engine image |
-| engine.image.tag | string | `"release-260630"` | tag defines which Deepgram release to use for Engine containers |
+| engine.image.tag | string | `"release-260714"` | tag defines which Deepgram release to use for Engine containers |
 | engine.lifecycle | object | `` | Configuration for container lifecycle hooks |
 | engine.lifecycle.postStart.command | list | `[]` | Command to execute in a postStart hook. Leave empty to disable. Example: ["/sbin/ldconfig"] |
 | engine.livenessProbe | object | `` | Liveness probe customization for Engine pods. |
@@ -482,7 +482,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | licenseProxy.extraEnv | list | `[]` | Extra environment variables for the License Proxy container. |
 | licenseProxy.image.path | string | `"quay.io/deepgram/self-hosted-license-proxy"` | path configures the image path to use for creating License Proxy containers. You may change this from the public Quay image path if you have imported Deepgram images into a private container registry. |
 | licenseProxy.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram License Proxy image |
-| licenseProxy.image.tag | string | `"release-260630"` | tag defines which Deepgram release to use for License Proxy containers |
+| licenseProxy.image.tag | string | `"release-260714"` | tag defines which Deepgram release to use for License Proxy containers |
 | licenseProxy.keepUpstreamServerAsBackup | bool | `true` | Even with a License Proxy deployed, API and Engine pods can be configured to keep the upstream `license.deepgram.com` license server as a fallback licensing option if the License Proxy is unavailable. Disable this option if you are restricting API/Engine Pod network access for security reasons, and only the License Proxy should send egress traffic to the upstream license server. |
 | licenseProxy.livenessProbe | object | `` | Liveness probe customization for Proxy pods. |
 | licenseProxy.namePrefix | string | `"deepgram-license-proxy"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram License Proxy containers. |

--- a/charts/deepgram-self-hosted/samples/04-aura-2-setup.values.yaml
+++ b/charts/deepgram-self-hosted/samples/04-aura-2-setup.values.yaml
@@ -42,7 +42,7 @@ scaling:
 # API configuration for English Aura-2
 api:
   image:
-    tag: release-260630
+    tag: release-260714
   
   # Configure driver pool to connect to both language engines
   driverPool:
@@ -55,7 +55,7 @@ api:
 # Engine configuration for Aura-2
 engine:
   image:
-    tag: release-260630
+    tag: release-260714
   
   # Aura-2 requires more resources than standard models
   resources:
@@ -113,7 +113,7 @@ licenseProxy:
   keepUpstreamServerAsBackup: true
   
   image:
-    tag: release-260630
+    tag: release-260714
 
 # Monitoring configuration for Aura-2
 # Enable Prometheus stack for metrics collection

--- a/charts/deepgram-self-hosted/samples/06-aura-2-polyglot-setup.values.yaml
+++ b/charts/deepgram-self-hosted/samples/06-aura-2-polyglot-setup.values.yaml
@@ -42,7 +42,7 @@ scaling:
 # API configuration for English and Polyglot Aura-2
 api:
   image:
-    tag: release-260630
+    tag: release-260714
 
   # Configure driver pool to connect to both language engines
   driverPool:
@@ -55,7 +55,7 @@ api:
 # Engine configuration for Aura-2
 engine:
   image:
-    tag: release-260630
+    tag: release-260714
 
   # Aura-2 requires more resources than standard models
   resources:
@@ -113,7 +113,7 @@ licenseProxy:
   keepUpstreamServerAsBackup: true
 
   image:
-    tag: release-260630
+    tag: release-260714
 
 # Monitoring configuration for Aura-2
 # Enable Prometheus stack for metrics collection

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -256,7 +256,7 @@ api:
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram API image
     pullPolicy: IfNotPresent
     # -- tag defines which Deepgram release to use for API containers
-    tag: release-260630
+    tag: release-260714
 
   # -- Additional labels to add to API resources
   additionalLabels: {}
@@ -494,7 +494,7 @@ engine:
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram Engine image
     pullPolicy: IfNotPresent
     # -- tag defines which Deepgram release to use for Engine containers
-    tag: release-260630
+    tag: release-260714
 
   # -- Additional labels to add to Engine resources
   additionalLabels: {}
@@ -889,7 +889,7 @@ licenseProxy:
     # Deepgram images into a private container registry.
     path: quay.io/deepgram/self-hosted-license-proxy
     # -- tag defines which Deepgram release to use for License Proxy containers
-    tag: release-260630
+    tag: release-260714
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram
     # License Proxy image
     pullPolicy: IfNotPresent
@@ -1059,7 +1059,7 @@ billing:
     # Deepgram images into a private container registry.
     path: quay.io/deepgram/self-hosted-billing
     # -- tag defines which Deepgram release to use for Billing containers
-    tag: release-260630
+    tag: release-260714
     # -- pullPolicy configures how the Kubelet attempts to pull the Deepgram
     # Billing image
     pullPolicy: IfNotPresent

--- a/docker/docker-compose.aura-2-polyglot.yml
+++ b/docker/docker-compose.aura-2-polyglot.yml
@@ -15,7 +15,7 @@ services:
   # The speech API service.
   # English Language Aura-2
   api-en:
-    image: quay.io/deepgram/self-hosted-api:release-260630
+    image: quay.io/deepgram/self-hosted-api:release-260714
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -42,7 +42,7 @@ services:
 
   # Polyglot Aura-2 (Dutch, German, French, Italian, Japanese)
   api-polyglot:
-    image: quay.io/deepgram/self-hosted-api:release-260630
+    image: quay.io/deepgram/self-hosted-api:release-260714
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -70,7 +70,7 @@ services:
   # The speech engine service.
   # English Language Aura-2 Driver
   engine-en:
-    image: quay.io/deepgram/self-hosted-engine:release-260630
+    image: quay.io/deepgram/self-hosted-engine:release-260714
     restart: always
 
     # Utilize a GPU, if available.
@@ -103,7 +103,7 @@ services:
 
   # Polyglot (Dutch, German, French, Italian, Japanese) Aura-2 Driver
   engine-polyglot:
-    image: quay.io/deepgram/self-hosted-engine:release-260630
+    image: quay.io/deepgram/self-hosted-engine:release-260714
     restart: always
 
     # Utilize a GPU, if available.
@@ -136,7 +136,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260630
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260714
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/docker/docker-compose.aura-2.yml
+++ b/docker/docker-compose.aura-2.yml
@@ -15,7 +15,7 @@ services:
   # The speech API service.
   # English Language Aura-2
   api-en:
-    image: quay.io/deepgram/self-hosted-api:release-260630
+    image: quay.io/deepgram/self-hosted-api:release-260714
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -42,7 +42,7 @@ services:
 
   # Spanish Language Aura-2
   api-es:
-    image: quay.io/deepgram/self-hosted-api:release-260630
+    image: quay.io/deepgram/self-hosted-api:release-260714
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -70,7 +70,7 @@ services:
   # The speech engine service.
   # English Language Aura-2 Driver
   engine-en:
-    image: quay.io/deepgram/self-hosted-engine:release-260630
+    image: quay.io/deepgram/self-hosted-engine:release-260714
     restart: always
 
     # Utilize a GPU, if available.
@@ -103,7 +103,7 @@ services:
 
   # Spanish Language Aura-2 Driver
   engine-es:
-    image: quay.io/deepgram/self-hosted-engine:release-260630
+    image: quay.io/deepgram/self-hosted-engine:release-260714
     restart: always
 
     # Utilize a GPU, if available.
@@ -136,7 +136,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260630
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260714
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/docker/docker-compose.license-proxy.yml
+++ b/docker/docker-compose.license-proxy.yml
@@ -14,7 +14,7 @@ x-env: &env
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-260630
+    image: quay.io/deepgram/self-hosted-api:release-260714
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -40,7 +40,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-260630
+    image: quay.io/deepgram/self-hosted-engine:release-260714
     restart: always
 
     # Utilize a GPU, if available.
@@ -68,7 +68,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260630
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260714
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/docker/docker-compose.standard.yml
+++ b/docker/docker-compose.standard.yml
@@ -14,7 +14,7 @@ x-env: &env
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-260630
+    image: quay.io/deepgram/self-hosted-api:release-260714
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -36,7 +36,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-260630
+    image: quay.io/deepgram/self-hosted-engine:release-260714
     restart: always
 
     # Utilize a GPU, if available.

--- a/podman/podman-compose.aura-2.yml
+++ b/podman/podman-compose.aura-2.yml
@@ -4,7 +4,7 @@ services:
   # The speech API service.
   # English Language Aura-2
   api-en:
-    image: quay.io/deepgram/self-hosted-api:release-260630
+    image: quay.io/deepgram/self-hosted-api:release-260714
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -38,7 +38,7 @@ services:
 
   # Spanish Language Aura-2
   api-es:
-    image: quay.io/deepgram/self-hosted-api:release-260630
+    image: quay.io/deepgram/self-hosted-api:release-260714
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -73,7 +73,7 @@ services:
   # The speech engine service.
   # English Language Aura-2 Driver
   engine-en:
-    image: quay.io/deepgram/self-hosted-engine:release-260630
+    image: quay.io/deepgram/self-hosted-engine:release-260714
     restart: always
 
     # Utilize a GPU, if available.
@@ -114,7 +114,7 @@ services:
 
   # Spanish Language Aura-2 Driver
   engine-es:
-    image: quay.io/deepgram/self-hosted-engine:release-260630
+    image: quay.io/deepgram/self-hosted-engine:release-260714
     restart: always
 
     # Utilize a GPU, if available.
@@ -155,7 +155,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260630
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260714
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/podman/podman-compose.license-proxy.yml
+++ b/podman/podman-compose.license-proxy.yml
@@ -3,7 +3,7 @@
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-260630
+    image: quay.io/deepgram/self-hosted-api:release-260714
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -37,7 +37,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-260630
+    image: quay.io/deepgram/self-hosted-engine:release-260714
     restart: always
 
     # Utilize a GPU, if available.
@@ -74,7 +74,7 @@ services:
 
   # The service to validate your Deepgram license
   license-proxy:
-    image: quay.io/deepgram/self-hosted-license-proxy:release-260630
+    image: quay.io/deepgram/self-hosted-license-proxy:release-260714
     restart: always
 
     # Here we expose the License Proxy status port to the host machine. The container port

--- a/podman/podman-compose.standard.yml
+++ b/podman/podman-compose.standard.yml
@@ -3,7 +3,7 @@
 services:
   # The speech API service.
   api:
-    image: quay.io/deepgram/self-hosted-api:release-260630
+    image: quay.io/deepgram/self-hosted-api:release-260714
     restart: always
 
     # Here we expose the API port to the host machine. The container port
@@ -33,7 +33,7 @@ services:
 
   # The speech engine service.
   engine:
-    image: quay.io/deepgram/self-hosted-engine:release-260630
+    image: quay.io/deepgram/self-hosted-engine:release-260714
     restart: always
 
     # Utilize a GPU, if available.


### PR DESCRIPTION
Bumps every default container tag from `release-260630` to `release-260714` and cuts Helm chart `0.40.0`.

- `values.yaml` — all four image tags (API, Engine, License Proxy, Billing)
- `Chart.yaml` — `version: 0.40.0`, `appVersion: release-260714`
- `CHANGELOG.md` — 0.40.0 entry + comparison links
- Aura-2 samples, all docker-compose and podman-compose files
- `README.md` regenerated via helm-docs

Verification: `grep -r release-260630 --include='*.yml' --include='*.yaml'` returns only historical CHANGELOG references.

Release context: all four `release-260714` images are digest-verified retags of the internally validated builds; the full validation battery + E2E (batch, streaming v1, Flux streaming v2) passed on the public tags on the test fleet. Companion changelog PR: deepgram/deepgram-docs#1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)