### PR TITLE
Set LD_LIBRARY_PATH on GPU Engine containers for GKE driver mounts

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## [0.40.2] - 2026-07-21
+
+### Fixed
+
+- Engine pods on GKE with Container-Optimized OS crashed on startup with `libcuda.so.1: cannot open shared object file` when using Engine images `release-260611` or newer. GKE's device plugin mounts the host NVIDIA driver at `/usr/local/nvidia` without the NVIDIA container toolkit, and [expects workloads to reference it via `LD_LIBRARY_PATH`](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda) — a path older Engine images baked in but newer images do not. The chart now sets `LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/nvidia/lib` on GPU-enabled Engine containers; this is a no-op in environments where the NVIDIA container toolkit injects the driver libraries. See [discussion #1626](https://github.com/orgs/deepgram/discussions/1626).
+
 ## [0.40.1] - 2026-07-17
 
 ### Added
@@ -495,7 +501,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Initial implementation of the Helm chart.
 
-[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.40.1...HEAD
+[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.40.2...HEAD
+[0.40.2]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.40.1...deepgram-self-hosted-0.40.2
 [0.40.1]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.40.0...deepgram-self-hosted-0.40.1
 [0.40.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.39.0...deepgram-self-hosted-0.40.0
 [0.39.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.38.0...deepgram-self-hosted-0.39.0

--- a/charts/deepgram-self-hosted/Chart.yaml
+++ b/charts/deepgram-self-hosted/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: deepgram-self-hosted
 type: application
-version: 0.40.1
+version: 0.40.2
 appVersion: "release-260714"
 description: A Helm chart for running Deepgram services in a self-hosted environment
 home: "https://developers.deepgram.com/docs/self-hosted-introduction"

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -1,6 +1,6 @@
 # deepgram-self-hosted
 
-![Version: 0.40.1](https://img.shields.io/badge/Version-0.40.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260714](https://img.shields.io/badge/AppVersion-release--260714-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
+![Version: 0.40.2](https://img.shields.io/badge/Version-0.40.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260714](https://img.shields.io/badge/AppVersion-release--260714-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
 
 A Helm chart for running Deepgram services in a self-hosted environment
 
@@ -234,6 +234,17 @@ If you encounter issues while deploying or using Deepgram, consider the followin
        helm get values [RELEASE_NAME] > my-deployed-values.yaml
        ```
    - Provide the collected diagnostic information to Deepgram for assistance.
+
+6. GKE: Engine pods crash on startup with `libcuda.so.1: cannot open shared object file`:
+   - GKE with Container-Optimized OS mounts the host NVIDIA driver at `/usr/local/nvidia` without the NVIDIA container toolkit, and [expects workloads to reference it via `LD_LIBRARY_PATH`](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda). Engine images `release-260611` and newer no longer bake this path into the image.
+   - Chart version `0.40.2` and later set this automatically. On older chart versions, add it manually:
+       ```yaml
+       engine:
+         extraEnv:
+           - name: LD_LIBRARY_PATH
+             value: "/usr/local/nvidia/lib64:/usr/local/nvidia/lib"
+       ```
+   - After the Engine pod starts, confirm GPU inference in its logs: `Using devices: Gpu(0)`.
 
 ## Values
 

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -244,7 +244,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
            - name: LD_LIBRARY_PATH
              value: "/usr/local/nvidia/lib64:/usr/local/nvidia/lib"
        ```
-   - After the Engine pod starts, confirm GPU inference in its logs: `Using devices: Gpu(0)`.
+   - After the Engine pod starts, confirm GPU inference in its logs: look for GPU startup lines such as `Setting GPU model cache size based on auto lookup table. gpu_id=Gpu(0) gpu_name=...` or `impeller::config: Using devices: Gpu(0)`.
 
 ## Values
 

--- a/charts/deepgram-self-hosted/README.md.gotmpl
+++ b/charts/deepgram-self-hosted/README.md.gotmpl
@@ -225,6 +225,17 @@ If you encounter issues while deploying or using Deepgram, consider the followin
        ```
    - Provide the collected diagnostic information to Deepgram for assistance.
 
+6. GKE: Engine pods crash on startup with `libcuda.so.1: cannot open shared object file`:
+   - GKE with Container-Optimized OS mounts the host NVIDIA driver at `/usr/local/nvidia` without the NVIDIA container toolkit, and [expects workloads to reference it via `LD_LIBRARY_PATH`](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda). Engine images `release-260611` and newer no longer bake this path into the image.
+   - Chart version `0.40.2` and later set this automatically. On older chart versions, add it manually:
+       ```yaml
+       engine:
+         extraEnv:
+           - name: LD_LIBRARY_PATH
+             value: "/usr/local/nvidia/lib64:/usr/local/nvidia/lib"
+       ```
+   - After the Engine pod starts, confirm GPU inference in its logs: `Using devices: Gpu(0)`.
+
 {{ template "chart.valuesSection" . }}
 
 {{ template "chart.maintainersSection" . }}

--- a/charts/deepgram-self-hosted/README.md.gotmpl
+++ b/charts/deepgram-self-hosted/README.md.gotmpl
@@ -234,7 +234,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
            - name: LD_LIBRARY_PATH
              value: "/usr/local/nvidia/lib64:/usr/local/nvidia/lib"
        ```
-   - After the Engine pod starts, confirm GPU inference in its logs: `Using devices: Gpu(0)`.
+   - After the Engine pod starts, confirm GPU inference in its logs: look for GPU startup lines such as `Setting GPU model cache size based on auto lookup table. gpu_id=Gpu(0) gpu_name=...` or `impeller::config: Using devices: Gpu(0)`.
 
 {{ template "chart.valuesSection" . }}
 

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -159,6 +159,20 @@ spec:
         - name: NVIDIA_DRIVER_CAPABILITIES
           value: "compute,utility"
         {{- end }}
+        {{- if gt $gpuRequest 0 }}
+        # GKE with Container-Optimized OS does not use the NVIDIA container toolkit:
+        # its device plugin mounts the host driver at /usr/local/nvidia and expects
+        # workloads to reference it via LD_LIBRARY_PATH
+        # (https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda).
+        # Engine images prior to release-260611 baked these paths into the image;
+        # newer images rely on the container toolkit's ldconfig injection instead, so
+        # without this variable the Engine crashes on GKE with
+        # `libcuda.so.1: cannot open shared object file`. The Engine image registers
+        # its own bundled libraries via ldconfig, and these directories do not exist
+        # in non-GKE environments, so this is a no-op everywhere else.
+        - name: LD_LIBRARY_PATH
+          value: "/usr/local/nvidia/lib64:/usr/local/nvidia/lib"
+        {{- end }}
         {{- if and $.Values.aura2.enabled (or (not $.Values.agent.enabled) (eq $type "agent-text-to-speech")) }}
         {{- if $.Values.aura2.english.enabled }}
         - name: IMPELLER_AURA2_MAX_BATCH_SIZE


### PR DESCRIPTION
## Proposed changes

Engine images since `release-260611` (the container refactor) register their bundled libraries via `ldconfig` at build time instead of a baked-in `LD_LIBRARY_PATH`, relying on the NVIDIA container toolkit to inject `libcuda` and refresh the linker cache at container create. GKE with Container-Optimized OS does not use the toolkit: its device plugin mounts the host driver at `/usr/local/nvidia`, and [GCP's GPU documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda) expects workloads to reference it via `LD_LIBRARY_PATH`. Since the refactor, Engine pods on GKE crash on startup with:

```
impeller: error while loading shared libraries: libcuda.so.1: cannot open shared object file: No such file or directory
```

This was reported in https://github.com/orgs/deepgram/discussions/1626 and has since been hit by multiple GKE self-hosted deployments upgrading from `release-260528` to `release-260611`+ (e.g. chart `0.37.0` → `0.39.0`).

This PR sets `LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/nvidia/lib` on GPU-enabled Engine containers — mirroring what pre-refactor images inherited from the CUDA base image, and following the pattern of #166, which moved `NVIDIA_VISIBLE_DEVICES`/`NVIDIA_DRIVER_CAPABILITIES` into the chart after the same refactor:

- The directories do not exist outside GKE, where the dynamic linker silently ignores them → no-op on GPU Operator / container-toolkit clusters.
- The Engine image's own libraries still resolve via its `ldconfig` cache, so there is no interaction with bundled libraries.
- A user-supplied `engine.extraEnv` entry for `LD_LIBRARY_PATH` still takes precedence, since `extraEnv` renders later and Kubernetes uses the last duplicate env entry.
- Not set on CPU-only Engine pods (`requests.gpu: 0`).

Also adds a GKE troubleshooting entry to the chart README (including the `engine.extraEnv` workaround for older chart versions) and a `0.40.2` changelog entry.

## Types of changes

What types of changes does your code introduce to the Deepgram self-hosted resources?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
  - `helm lint` passes and `helm-docs` was run per CONTRIBUTING. Verified via a `helm template` render matrix: default GPU Engine pods get the variable; CPU-only pods (`requests.gpu: 0`) do not; `useNvidiaDevicePlugin: true` pods do; a user `engine.extraEnv` override renders after the chart's entry and wins. The equivalent env var (applied via `engine.extraEnv`) is already running in production on GKE deployments affected by this issue; this exact chart build has not yet been re-validated on a live GKE cluster.
- [x] I have added necessary documentation (if appropriate)

## Further comments

Alternatives considered:

- **Image-side fix** (restore a minimal `ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/nvidia/lib` in the Engine image, as NVIDIA's own CUDA base images do): more universal, since it also covers non-Helm Kubernetes deployments — but #166 established the chart as the home for environment-compat variables after the container refactor, and the image intentionally moved to `ldconfig`. Happy to coordinate an image-side change instead if preferred; an entrypoint-time `ldconfig` refresh would additionally cover the Flux subprocess on GKE (it launches with `env -u LD_LIBRARY_PATH`, so env-var-based fixes don't reach it and the current workaround is a `postStart` hook).
- **Values-gated flag** (e.g. `engine.gke.enabled`): rejected — the variable is harmless where the paths don't exist, and gating it behind a flag preserves the failure mode for the next GKE deployment.