### PR TITLE
Set full LD_LIBRARY_PATH to fix pre-260611 Engine images (#179)

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## [0.40.3] - 2026-07-28
+
+### Fixed
+
+- Chart `0.40.2` set `LD_LIBRARY_PATH` on GPU Engine containers to only the GKE driver directories. Because a Kubernetes env var replaces the image's `ENV` of the same name, this overrode the baked-in value that Engine images prior to `release-260611` rely on to locate their own bundled libraries, and those images failed to start with errors such as `libicui18n.so.74: cannot open shared object file` ([#179](https://github.com/deepgram/self-hosted-resources/issues/179)). The chart now sets the full historical path list (bundled library directories plus the GKE driver directories), restoring pre-`0.40.2` behavior for older images while keeping the GKE fix for `release-260611`+. Directories that do not exist in a given image or environment are ignored by the dynamic linker.
+
 ## [0.40.2] - 2026-07-21
 
 ### Fixed
@@ -501,7 +507,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Initial implementation of the Helm chart.
 
-[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.40.2...HEAD
+[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.40.3...HEAD
+[0.40.3]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.40.2...deepgram-self-hosted-0.40.3
 [0.40.2]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.40.1...deepgram-self-hosted-0.40.2
 [0.40.1]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.40.0...deepgram-self-hosted-0.40.1
 [0.40.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.39.0...deepgram-self-hosted-0.40.0

--- a/charts/deepgram-self-hosted/Chart.yaml
+++ b/charts/deepgram-self-hosted/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: deepgram-self-hosted
 type: application
-version: 0.40.2
+version: 0.40.3
 appVersion: "release-260714"
 description: A Helm chart for running Deepgram services in a self-hosted environment
 home: "https://developers.deepgram.com/docs/self-hosted-introduction"

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -1,6 +1,6 @@
 # deepgram-self-hosted
 
-![Version: 0.40.2](https://img.shields.io/badge/Version-0.40.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260714](https://img.shields.io/badge/AppVersion-release--260714-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
+![Version: 0.40.3](https://img.shields.io/badge/Version-0.40.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260714](https://img.shields.io/badge/AppVersion-release--260714-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
 
 A Helm chart for running Deepgram services in a self-hosted environment
 
@@ -237,12 +237,12 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 
 6. GKE: Engine pods crash on startup with `libcuda.so.1: cannot open shared object file`:
    - GKE with Container-Optimized OS mounts the host NVIDIA driver at `/usr/local/nvidia` without the NVIDIA container toolkit, and [expects workloads to reference it via `LD_LIBRARY_PATH`](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda). Engine images `release-260611` and newer no longer bake this path into the image.
-   - Chart version `0.40.2` and later set this automatically. On older chart versions, add it manually:
+   - Chart version `0.40.3` and later set this automatically (`0.40.2` set an incomplete value that breaks Engine images older than `release-260611`; see the [chart CHANGELOG](./CHANGELOG.md)). On older chart versions, add it manually:
        ```yaml
        engine:
          extraEnv:
            - name: LD_LIBRARY_PATH
-             value: "/usr/local/nvidia/lib64:/usr/local/nvidia/lib"
+             value: "/openh264/lib64:/gstreamer/lib64:/libtorch/lib:/usr/local/cuda/lib64:/usr/local/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
        ```
    - After the Engine pod starts, confirm GPU inference in its logs: look for GPU startup lines such as `Setting GPU model cache size based on auto lookup table. gpu_id=Gpu(0) gpu_name=...` or `impeller::config: Using devices: Gpu(0)`.
 

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -1,6 +1,6 @@
 # deepgram-self-hosted
 
-![Version: 0.41.0](https://img.shields.io/badge/Version-0.41.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260728](https://img.shields.io/badge/AppVersion-release--260728-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
+![Version: 0.41.1](https://img.shields.io/badge/Version-0.41.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260728](https://img.shields.io/badge/AppVersion-release--260728-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
 
 A Helm chart for running Deepgram services in a self-hosted environment
 

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -237,7 +237,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 
 6. GKE: Engine pods crash on startup with `libcuda.so.1: cannot open shared object file`:
    - GKE with Container-Optimized OS mounts the host NVIDIA driver at `/usr/local/nvidia` without the NVIDIA container toolkit, and [expects workloads to reference it via `LD_LIBRARY_PATH`](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda). Engine images `release-260611` and newer no longer bake this path into the image.
-   - Chart version `0.40.3` and later set this automatically (`0.40.2` set an incomplete value that breaks Engine images older than `release-260611`; see the [chart CHANGELOG](./CHANGELOG.md)). On older chart versions, add it manually:
+   - Chart version `0.41.1` and later set this automatically (`0.40.2` set an incomplete value that breaks Engine images older than `release-260611`; see the [chart CHANGELOG](./CHANGELOG.md)). On older chart versions, add it manually:
        ```yaml
        engine:
          extraEnv:

--- a/charts/deepgram-self-hosted/README.md.gotmpl
+++ b/charts/deepgram-self-hosted/README.md.gotmpl
@@ -227,12 +227,12 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 
 6. GKE: Engine pods crash on startup with `libcuda.so.1: cannot open shared object file`:
    - GKE with Container-Optimized OS mounts the host NVIDIA driver at `/usr/local/nvidia` without the NVIDIA container toolkit, and [expects workloads to reference it via `LD_LIBRARY_PATH`](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda). Engine images `release-260611` and newer no longer bake this path into the image.
-   - Chart version `0.40.2` and later set this automatically. On older chart versions, add it manually:
+   - Chart version `0.40.3` and later set this automatically (`0.40.2` set an incomplete value that breaks Engine images older than `release-260611`; see the [chart CHANGELOG](./CHANGELOG.md)). On older chart versions, add it manually:
        ```yaml
        engine:
          extraEnv:
            - name: LD_LIBRARY_PATH
-             value: "/usr/local/nvidia/lib64:/usr/local/nvidia/lib"
+             value: "/openh264/lib64:/gstreamer/lib64:/libtorch/lib:/usr/local/cuda/lib64:/usr/local/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
        ```
    - After the Engine pod starts, confirm GPU inference in its logs: look for GPU startup lines such as `Setting GPU model cache size based on auto lookup table. gpu_id=Gpu(0) gpu_name=...` or `impeller::config: Using devices: Gpu(0)`.
 

--- a/charts/deepgram-self-hosted/README.md.gotmpl
+++ b/charts/deepgram-self-hosted/README.md.gotmpl
@@ -227,7 +227,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 
 6. GKE: Engine pods crash on startup with `libcuda.so.1: cannot open shared object file`:
    - GKE with Container-Optimized OS mounts the host NVIDIA driver at `/usr/local/nvidia` without the NVIDIA container toolkit, and [expects workloads to reference it via `LD_LIBRARY_PATH`](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda). Engine images `release-260611` and newer no longer bake this path into the image.
-   - Chart version `0.40.3` and later set this automatically (`0.40.2` set an incomplete value that breaks Engine images older than `release-260611`; see the [chart CHANGELOG](./CHANGELOG.md)). On older chart versions, add it manually:
+   - Chart version `0.41.1` and later set this automatically (`0.40.2` set an incomplete value that breaks Engine images older than `release-260611`; see the [chart CHANGELOG](./CHANGELOG.md)). On older chart versions, add it manually:
        ```yaml
        engine:
          extraEnv:

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -164,14 +164,17 @@ spec:
         # its device plugin mounts the host driver at /usr/local/nvidia and expects
         # workloads to reference it via LD_LIBRARY_PATH
         # (https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cuda).
-        # Engine images prior to release-260611 baked these paths into the image;
-        # newer images rely on the container toolkit's ldconfig injection instead, so
-        # without this variable the Engine crashes on GKE with
-        # `libcuda.so.1: cannot open shared object file`. The Engine image registers
-        # its own bundled libraries via ldconfig, and these directories do not exist
-        # in non-GKE environments, so this is a no-op everywhere else.
+        # Without this variable, release-260611+ Engine images crash on GKE with
+        # `libcuda.so.1: cannot open shared object file`.
+        # NOTE: a Kubernetes env var REPLACES the image's ENV of the same name rather
+        # than appending to it, and Engine images prior to release-260611 rely on
+        # their baked-in LD_LIBRARY_PATH to locate their own bundled libraries
+        # (see issue #179), so this must be the full historical path list, not just
+        # the GKE driver directories. Directories that do not exist in a given image
+        # or environment are ignored by the dynamic linker, so this is safe on
+        # non-GKE clusters and on all Engine image generations.
         - name: LD_LIBRARY_PATH
-          value: "/usr/local/nvidia/lib64:/usr/local/nvidia/lib"
+          value: "/openh264/lib64:/gstreamer/lib64:/libtorch/lib:/usr/local/cuda/lib64:/usr/local/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
         {{- end }}
         {{- if and $.Values.aura2.enabled (or (not $.Values.agent.enabled) (eq $type "agent-text-to-speech")) }}
         {{- if $.Values.aura2.english.enabled }}


### PR DESCRIPTION
## Proposed changes

Fixes #179 — a regression introduced by #177 (chart `0.40.2`) for Engine images older than `release-260611`.

**Mechanism:** a Kubernetes env var replaces the image's `ENV` of the same name rather than appending to it. Pre-`release-260611` Engine images rely on their baked-in `LD_LIBRARY_PATH` to locate their own bundled libraries (they predate the image-side `ldconfig` registration introduced by the container refactor), so `0.40.2`'s nvidia-only value hid those libraries from the dynamic linker and the Engine failed at exec with `libicui18n.so.74: cannot open shared object file`.

**Fix:** set the full historical path list — bundled library directories plus the GKE driver directories:

```
/openh264/lib64:/gstreamer/lib64:/libtorch/lib:/usr/local/cuda/lib64:/usr/local/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
```

This is byte-identical to what pre-`260611` images bake in (restoring their behavior everywhere, including EKS), keeps the GKE `libcuda.so.1` fix for `release-260611`+ (whose bundled-library paths are unchanged and additionally `ldconfig`-registered), and remains a no-op wherever directories don't exist. A user-supplied `engine.extraEnv` override still renders later and wins.

**Where this exact value comes from — verified against the shipped images themselves** (four independent confirmations that agree byte-for-byte):

1. **The shipped image configs, read directly from the registry (2026-07-28).** The image configs of `quay.io/deepgram/self-hosted-engine:release-260514` and `:release-260528` each bake exactly this 7-directory `ENV LD_LIBRARY_PATH`, byte-identical to the value in this PR; `:release-260611` and `:release-260714` bake none — confirming both the value and the generational boundary on the actual artifacts customers run.
2. **Field captures from running images — the AWS evidence.** The `printenv` capture in #179 is from a running `release-260514` Engine pod **on EKS**: same 7-directory string. The environment capture from the original GKE report against `release-260528` is identical — two releases, two clouds, same value. (Re-verified first-party: `printenv LD_LIBRARY_PATH` inside the pulled `release-260514` image reproduces #179's capture verbatim.) On EKS the trailing `/usr/local/nvidia/{lib,lib64}` entries don't exist (the driver is injected by the NVIDIA container toolkit from the AMI), and the dynamic linker silently skips non-existent entries — so for AWS this value is precisely "the image's own environment, restored", no more and no less.
3. **The pre-refactor Engine Dockerfile.** Its runtime stage builds `FROM nvidia/cuda:12.4.1-cudnn-runtime-rockylinux9` and sets `ENV LD_LIBRARY_PATH="/openh264/lib64:/gstreamer/lib64:/libtorch/lib:/usr/local/cuda/lib64:/usr/local/lib:${LD_LIBRARY_PATH}"` — five explicit entries, with the trailing `${LD_LIBRARY_PATH}` expanding at build time to the CUDA base image's value.
4. **The NVIDIA base image config, checked directly.** The Docker Hub config blob for `nvidia/cuda:12.4.1-cudnn-runtime-rockylinux9` (linux/amd64) contains exactly `LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64` — NVIDIA ships this in its base images precisely for GKE-style host-driver mounts. Five explicit + two inherited = these seven directories, in this order. Both field captures end `…/nvidia/lib:/usr/local/nvidia/lib64` — `lib` *before* `lib64`, the base image's ordering rather than one someone would hand-compose — confirming the expansion. (The refactor diff also removed a second `ENV LD_LIBRARY_PATH` containing `/usr/local/cuda-12.8/lib64:/usr/lib64`; that line belongs to the *builder* stage, not the shipped runtime image, which is why it is absent from both field captures and correctly excluded here.)

Byte-identical matters: for pre-`260611` images this restores literally their own environment — zero behavioral delta from what has worked for years — rather than a hand-composed "improved" list that could introduce a new variant of the same bug class.

## How this was verified

**On the real shipped images (2026-07-28).** Both Engine generations were pulled from Quay (`release-260514` legacy, `release-260714` modern) and their entrypoint binary (`/bin/impeller`) was link-traced with `LD_TRACE_LOADED_OBJECTS=1` under env contracts **rendered from the actual charts** (`deepgram-self-hosted-0.40.2` tag vs. this branch), on both driver topologies: **EKS-mock** (driver injected into a trusted linker directory, toolkit-style — no `/usr/local/nvidia`) and **GKE-mock** (driver bind-mounted at `/usr/local/nvidia/lib64`, no toolkit).

| # | Real image | Chart env | Topology | Result |
|---|---|---|---|---|
| R1 | `release-260514` | `0.40.2` | EKS | **fails exactly as #179**: `libicui18n.so.74 => not found` (Grant's precise error) + 8 more bundled libraries hidden |
| R2 | `release-260514` | this branch | EKS | all 41 traced libraries resolve; `libicui18n.so.74` from `/usr/local/lib` |
| R3 | `release-260514` | none (baked env) | EKS | pre-`0.40.2` baseline: fully resolves — what worked before the regression |
| R4 | `release-260514` | this branch | GKE | fully resolves; `libcuda.so.1` from `/usr/local/nvidia/lib64` |
| R5 | `release-260714` | this branch | GKE | fully resolves; `libcuda.so.1` from the GKE mount — the #177 fix is preserved |
| R6 | `release-260714` | none | GKE | only `libcuda.so.1 => not found` — the original GKE break, detection control intact |

The same matrix was first developed against linker-level model images of both generations (reproducing #179 and the GKE break without registry credentials); those models and the smoke harness now live in the internal `deepgram/agent-skills` repo (see Further comments).

Also verified: `helm lint` passes; `helm-docs` run per CONTRIBUTING (README regenerates identically); render matrix — GPU pods get the full list, CPU-only pods (`requests.gpu: 0`) get none, `useNvidiaDevicePlugin: true` pods get it, and a user `engine.extraEnv` override renders later and wins (Kubernetes takes the last duplicate env entry).

Remaining boundary: not exercised on a live EKS/GKE cluster in this pass. Link resolution is fully determined by the three inputs pinned above (image, env contract, driver location), and #179 itself is the field observation of R1/R3 on a live EKS cluster.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have tested my changes in my local self-hosted environment
  - See "How this was verified" above for the full real-image reproduction and fix matrix.
- [x] I have added necessary documentation (if appropriate)

## Further comments

- **Why not a GKE-only flag** (suggested in #179): the full path list is correct for every image generation and environment simultaneously — nonexistent directories are ignored by the dynamic linker — without reintroducing a default-off footgun for the next GKE deployment.
- **Scope, per review feedback:** this PR is now chart-only. The diagnostic smoke script, the linker-level sim images, and the CI regression job that previously lived in this PR have been moved to the internal `deepgram/agent-skills` repo as the start of a **self-hosted debugging skill** (`skills/ops/self-hosted-debugging`), keeping internal diagnostics out of the public chart repo.
