### PR TITLE
Add logFormat values to select container log output format

### DIFF
--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## [0.45.0] - 2026-08-27
+
 ### Added
 
 - Added `api.logFormat`, `engine.logFormat`, `licenseProxy.logFormat`, and `billing.logFormat` to select a container's [log output format](https://developers.deepgram.com/docs/log-formats). Accepts `full`, `compact`, `pretty`, or `json`; an unrecognized value fails at template time rather than crash-looping the pod. Defaults to empty, which leaves each container on its own default (`full`) and renders the same arguments as before. Requires `release-260319` or later.
@@ -554,7 +556,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Initial implementation of the Helm chart.
 
-[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.43.0...HEAD
+[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.45.0...HEAD
+[0.45.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.44.0...deepgram-self-hosted-0.45.0
+[0.44.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.43.0...deepgram-self-hosted-0.44.0
 [0.43.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.42.0...deepgram-self-hosted-0.43.0
 [0.42.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.41.1...deepgram-self-hosted-0.42.0
 [0.41.1]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.41.0...deepgram-self-hosted-0.41.1

--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -10,10 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Added `api.logFormat`, `engine.logFormat`, `licenseProxy.logFormat`, and `billing.logFormat` to select a container's [log output format](https://developers.deepgram.com/docs/log-formats). Accepts `full`, `compact`, `pretty`, or `json`; an unrecognized value fails at template time rather than crash-looping the pod. Defaults to empty, which leaves each container on its own default (`full`) and renders the same arguments as before. Requires `release-260319` or later.
 
-### Notes
-
-- `--log-format` is a top-level option on the Deepgram binaries and must precede the `serve` subcommand, so the chart renders it there. Passing it after the subcommand — as the "Kubernetes" example on the Deepgram log formats documentation page currently shows — makes the container exit with `error: unexpected argument '--log-format' found`.
-
 ## [0.42.0] - 2026-08-12
 
 ### Changed

--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
-## [0.45.0] - 2026-08-27
+## [0.45.0] - 2026-09-01
 
 ### Added
 

--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Added `api.logFormat`, `engine.logFormat`, `licenseProxy.logFormat`, and `billing.logFormat` to select a container's [log output format](https://developers.deepgram.com/docs/log-formats). Accepts `full`, `compact`, `pretty`, or `json`; an unrecognized value fails at template time rather than crash-looping the pod. Defaults to empty, which leaves each container on its own default (`full`) and renders the same arguments as before. Requires `release-260319` or later.
+
 ## [0.43.0] - 2026-08-25
 
 ### Added

--- a/charts/deepgram-self-hosted/CHANGELOG.md
+++ b/charts/deepgram-self-hosted/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+### Added
+
+- Added `api.logFormat`, `engine.logFormat`, `licenseProxy.logFormat`, and `billing.logFormat` to select a container's [log output format](https://developers.deepgram.com/docs/log-formats). Accepts `full`, `compact`, `pretty`, or `json`; an unrecognized value fails at template time rather than crash-looping the pod. Defaults to empty, which leaves each container on its own default (`full`) and renders the same arguments as before. Requires `release-260319` or later.
+
+### Notes
+
+- `--log-format` is a top-level option on the Deepgram binaries and must precede the `serve` subcommand, so the chart renders it there. Passing it after the subcommand — as the "Kubernetes" example on the Deepgram log formats documentation page currently shows — makes the container exit with `error: unexpected argument '--log-format' found`.
+
 ## [0.42.0] - 2026-08-12
 
 ### Changed
@@ -532,7 +540,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Initial implementation of the Helm chart.
 
-[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.41.1...HEAD
+[unreleased]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.42.0...HEAD
+[0.42.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.41.1...deepgram-self-hosted-0.42.0
 [0.41.1]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.41.0...deepgram-self-hosted-0.41.1
 [0.41.0]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.40.2...deepgram-self-hosted-0.41.0
 [0.40.2]: https://github.com/deepgram/self-hosted-resources/compare/deepgram-self-hosted-0.40.1...deepgram-self-hosted-0.40.2

--- a/charts/deepgram-self-hosted/Chart.yaml
+++ b/charts/deepgram-self-hosted/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: deepgram-self-hosted
 type: application
-version: 0.44.0
+version: 0.45.0
 appVersion: "release-260826"
 description: A Helm chart for running Deepgram services in a self-hosted environment
 home: "https://developers.deepgram.com/docs/self-hosted-introduction"

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -1,6 +1,6 @@
 # deepgram-self-hosted
 
-![Version: 0.44.0](https://img.shields.io/badge/Version-0.44.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260826](https://img.shields.io/badge/AppVersion-release--260826-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
+![Version: 0.45.0](https://img.shields.io/badge/Version-0.45.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: release-260826](https://img.shields.io/badge/AppVersion-release--260826-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/deepgram-self-hosted)](https://artifacthub.io/packages/search?repo=deepgram-self-hosted)
 
 A Helm chart for running Deepgram services in a self-hosted environment
 

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -297,6 +297,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | api.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram API image |
 | api.image.tag | string | `"release-260812"` | tag defines which Deepgram release to use for API containers |
 | api.livenessProbe | object | `` | Liveness probe customization for API pods. |
+| api.logFormat | string | `""` | [Log output format](https://developers.deepgram.com/docs/log-formats) for the API container. One of `full`, `compact`, `pretty`, or `json`. Leave empty to use the container's own default (`full`). Requires `release-260319` or later. |
 | api.namePrefix | string | `"deepgram-api"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram API containers. |
 | api.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to API pods. |
 | api.pdb | object | `` | [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) for API pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled. |
@@ -355,6 +356,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | billing.licenseFile.secretKey | string | `"license.dg"` | Key within the Secret that contains the license file content |
 | billing.licenseFile.secretRef | string | `nil` | Name of the pre-configured K8s Secret containing your Deepgram license file |
 | billing.livenessProbe | object | `` | Liveness probe customization for Billing pods. |
+| billing.logFormat | string | `""` | [Log output format](https://developers.deepgram.com/docs/log-formats) for the Billing container. One of `full`, `compact`, `pretty`, or `json`. Leave empty to use the container's own default (`full`). Requires `release-260319` or later. |
 | billing.namePrefix | string | `"deepgram-billing"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram Billing containers. |
 | billing.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to Billing pods. |
 | billing.pdb | object | `` | [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) for Billing pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled. |
@@ -412,6 +414,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | engine.lifecycle | object | `` | Configuration for container lifecycle hooks |
 | engine.lifecycle.postStart.command | list | `[]` | Command to execute in a postStart hook. Leave empty to disable. Example: ["/sbin/ldconfig"] |
 | engine.livenessProbe | object | `` | Liveness probe customization for Engine pods. |
+| engine.logFormat | string | `""` | [Log output format](https://developers.deepgram.com/docs/log-formats) for the Engine container. One of `full`, `compact`, `pretty`, or `json`. Leave empty to use the container's own default (`full`). Requires `release-260319` or later. |
 | engine.metricsServer | object | `` | metricsServer exposes an endpoint on each Engine container for reporting inference-specific system metrics. See https://developers.deepgram.com/docs/metrics-guide#deepgram-engine for more details. |
 | engine.metricsServer.host | string | `"0.0.0.0"` | host is the IP address to listen on for metrics requests. You will want to listen on all interfaces to interact with other pods in the cluster. |
 | engine.metricsServer.port | int | `9991` | port to listen on for metrics requests |
@@ -504,6 +507,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | licenseProxy.image.tag | string | `"release-260812"` | tag defines which Deepgram release to use for License Proxy containers |
 | licenseProxy.keepUpstreamServerAsBackup | bool | `true` | Even with a License Proxy deployed, API and Engine pods can be configured to keep the upstream `license.deepgram.com` license server as a fallback licensing option if the License Proxy is unavailable. Disable this option if you are restricting API/Engine Pod network access for security reasons, and only the License Proxy should send egress traffic to the upstream license server. |
 | licenseProxy.livenessProbe | object | `` | Liveness probe customization for Proxy pods. |
+| licenseProxy.logFormat | string | `""` | [Log output format](https://developers.deepgram.com/docs/log-formats) for the License Proxy container. One of `full`, `compact`, `pretty`, or `json`. Leave empty to use the container's own default (`full`). Requires `release-260319` or later. |
 | licenseProxy.namePrefix | string | `"deepgram-license-proxy"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram License Proxy containers. |
 | licenseProxy.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to License Proxy pods. |
 | licenseProxy.pdb | object | `` | [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) for License Proxy pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled. |

--- a/charts/deepgram-self-hosted/README.md
+++ b/charts/deepgram-self-hosted/README.md
@@ -297,7 +297,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | api.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy configures how the Kubelet attempts to pull the Deepgram API image |
 | api.image.tag | string | `"release-260812"` | tag defines which Deepgram release to use for API containers |
 | api.livenessProbe | object | `` | Liveness probe customization for API pods. |
-| api.logFormat | string | `""` | [Log output format](https://developers.deepgram.com/docs/log-formats) for the API container. One of `full`, `compact`, `pretty`, or `json`. Leave empty to use the container's own default (`full`). Requires `release-260319` or later. |
+| api.logFormat | string | `""` | [Log output format](https://developers.deepgram.com/docs/log-formats) for the API container. One of `full`, `compact`, `pretty`, or `json`. Leave empty to use the container's own default (`full`). |
 | api.namePrefix | string | `"deepgram-api"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram API containers. |
 | api.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to API pods. |
 | api.pdb | object | `` | [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) for API pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled. |
@@ -356,7 +356,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | billing.licenseFile.secretKey | string | `"license.dg"` | Key within the Secret that contains the license file content |
 | billing.licenseFile.secretRef | string | `nil` | Name of the pre-configured K8s Secret containing your Deepgram license file |
 | billing.livenessProbe | object | `` | Liveness probe customization for Billing pods. |
-| billing.logFormat | string | `""` | [Log output format](https://developers.deepgram.com/docs/log-formats) for the Billing container. One of `full`, `compact`, `pretty`, or `json`. Leave empty to use the container's own default (`full`). Requires `release-260319` or later. |
+| billing.logFormat | string | `""` | [Log output format](https://developers.deepgram.com/docs/log-formats) for the Billing container. One of `full`, `compact`, `pretty`, or `json`. Leave empty to use the container's own default (`full`). |
 | billing.namePrefix | string | `"deepgram-billing"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram Billing containers. |
 | billing.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to Billing pods. |
 | billing.pdb | object | `` | [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) for Billing pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled. |
@@ -414,7 +414,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | engine.lifecycle | object | `` | Configuration for container lifecycle hooks |
 | engine.lifecycle.postStart.command | list | `[]` | Command to execute in a postStart hook. Leave empty to disable. Example: ["/sbin/ldconfig"] |
 | engine.livenessProbe | object | `` | Liveness probe customization for Engine pods. |
-| engine.logFormat | string | `""` | [Log output format](https://developers.deepgram.com/docs/log-formats) for the Engine container. One of `full`, `compact`, `pretty`, or `json`. Leave empty to use the container's own default (`full`). Requires `release-260319` or later. |
+| engine.logFormat | string | `""` | [Log output format](https://developers.deepgram.com/docs/log-formats) for the Engine container. One of `full`, `compact`, `pretty`, or `json`. Leave empty to use the container's own default (`full`). |
 | engine.metricsServer | object | `` | metricsServer exposes an endpoint on each Engine container for reporting inference-specific system metrics. See https://developers.deepgram.com/docs/metrics-guide#deepgram-engine for more details. |
 | engine.metricsServer.host | string | `"0.0.0.0"` | host is the IP address to listen on for metrics requests. You will want to listen on all interfaces to interact with other pods in the cluster. |
 | engine.metricsServer.port | int | `9991` | port to listen on for metrics requests |
@@ -507,7 +507,7 @@ If you encounter issues while deploying or using Deepgram, consider the followin
 | licenseProxy.image.tag | string | `"release-260812"` | tag defines which Deepgram release to use for License Proxy containers |
 | licenseProxy.keepUpstreamServerAsBackup | bool | `true` | Even with a License Proxy deployed, API and Engine pods can be configured to keep the upstream `license.deepgram.com` license server as a fallback licensing option if the License Proxy is unavailable. Disable this option if you are restricting API/Engine Pod network access for security reasons, and only the License Proxy should send egress traffic to the upstream license server. |
 | licenseProxy.livenessProbe | object | `` | Liveness probe customization for Proxy pods. |
-| licenseProxy.logFormat | string | `""` | [Log output format](https://developers.deepgram.com/docs/log-formats) for the License Proxy container. One of `full`, `compact`, `pretty`, or `json`. Leave empty to use the container's own default (`full`). Requires `release-260319` or later. |
+| licenseProxy.logFormat | string | `""` | [Log output format](https://developers.deepgram.com/docs/log-formats) for the License Proxy container. One of `full`, `compact`, `pretty`, or `json`. Leave empty to use the container's own default (`full`). |
 | licenseProxy.namePrefix | string | `"deepgram-license-proxy"` | namePrefix is the prefix to apply to the name of all K8s objects associated with the Deepgram License Proxy containers. |
 | licenseProxy.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) to apply to License Proxy pods. |
 | licenseProxy.pdb | object | `` | [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) for License Proxy pods. Set exactly one of `minAvailable` or `maxUnavailable` when enabled. |

--- a/charts/deepgram-self-hosted/templates/_helpers.tpl
+++ b/charts/deepgram-self-hosted/templates/_helpers.tpl
@@ -32,12 +32,22 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Render the --log-format flag for a component, or an empty string if unset.
 Callers must place the result ahead of the subcommand: the Deepgram binaries
 expose --log-format only as a top-level option, and reject it after `serve`.
-Takes a dict of "key" (values path, for the error message) and "value".
+Takes a dict of "key" (values path, for the error message), "value", and the
+component's "extraEnv", which is checked for the legacy JSON=true variable:
+the containers panic when it is combined with any format other than json.
 */}}
 {{- define "deepgram-self-hosted.logFormatArg" -}}
 {{- with .value -}}
 {{- if not (has . (list "full" "compact" "pretty" "json")) -}}
 {{- fail (printf "Error: %s must be one of full, compact, pretty, json (got %q)" $.key .) -}}
+{{- end -}}
+{{- if ne . "json" -}}
+{{- $envKey := printf "%s.extraEnv" (trimSuffix ".logFormat" $.key) -}}
+{{- range $.extraEnv -}}
+{{- if and (eq (toString (.name | default "")) "JSON") (eq (lower (toString (.value | default ""))) "true") -}}
+{{- fail (printf "Error: %s is %q, but %s sets JSON=true, which forces JSON output. The container panics when both are set. Remove the JSON variable, or set %s to json." $.key $.value $envKey $.key) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- printf "--log-format=%s" . -}}
 {{- end -}}

--- a/charts/deepgram-self-hosted/templates/_helpers.tpl
+++ b/charts/deepgram-self-hosted/templates/_helpers.tpl
@@ -27,3 +27,18 @@ Selector labels
 {{- define "deepgram-self-hosted.selectorLabels" -}}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Render the --log-format flag for a component, or an empty string if unset.
+Callers must place the result ahead of the subcommand: the Deepgram binaries
+expose --log-format only as a top-level option, and reject it after `serve`.
+Takes a dict of "key" (values path, for the error message) and "value".
+*/}}
+{{- define "deepgram-self-hosted.logFormatArg" -}}
+{{- with .value -}}
+{{- if not (has . (list "full" "compact" "pretty" "json")) -}}
+{{- fail (printf "Error: %s must be one of full, compact, pretty, json (got %q)" $.key .) -}}
+{{- end -}}
+{{- printf "--log-format=%s" . -}}
+{{- end -}}
+{{- end }}

--- a/charts/deepgram-self-hosted/templates/_helpers.tpl
+++ b/charts/deepgram-self-hosted/templates/_helpers.tpl
@@ -50,6 +50,10 @@ the containers panic when it is combined with any format other than json.
 {{- end -}}
 {{- end -}}
 {{- printf "--log-format=%s" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Reject FIPS mode unless every deployed component runs a FIPS image. Standard
 images are not built for FIPS: depending on the base OS, one either aborts at
 startup ("Failed to load FIPS provider", exit 101) or starts and reports

--- a/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
@@ -167,7 +167,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         command: [ "stem" ]
-        args: {{ compact (list "-v" (include "deepgram-self-hosted.logFormatArg" (dict "key" "api.logFormat" "value" .Values.api.logFormat)) "serve" "/etc/config/api.toml") | toJson }}
+        args: {{ compact (list "-v" (include "deepgram-self-hosted.logFormatArg" (dict "key" "api.logFormat" "value" .Values.api.logFormat "extraEnv" .Values.api.extraEnv)) "serve" "/etc/config/api.toml") | toJson }}
         resources:
           requests:
             memory: "{{ .Values.api.resources.requests.memory }}"

--- a/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/api/api.deployment.yaml
@@ -167,7 +167,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         command: [ "stem" ]
-        args: ["-v", "serve", "/etc/config/api.toml"]
+        args: {{ compact (list "-v" (include "deepgram-self-hosted.logFormatArg" (dict "key" "api.logFormat" "value" .Values.api.logFormat)) "serve" "/etc/config/api.toml") | toJson }}
         resources:
           requests:
             memory: "{{ .Values.api.resources.requests.memory }}"

--- a/charts/deepgram-self-hosted/templates/billing/billing.statefulset.yaml
+++ b/charts/deepgram-self-hosted/templates/billing/billing.statefulset.yaml
@@ -95,7 +95,7 @@ spec:
         {{- with .Values.billing.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        args: ["serve", "--config", "/etc/config/billing.toml"]
+        args: {{ compact (list (include "deepgram-self-hosted.logFormatArg" (dict "key" "billing.logFormat" "value" .Values.billing.logFormat)) "serve" "--config" "/etc/config/billing.toml") | toJson }}
         resources:
           requests:
             memory: "{{ .Values.billing.resources.requests.memory }}"

--- a/charts/deepgram-self-hosted/templates/billing/billing.statefulset.yaml
+++ b/charts/deepgram-self-hosted/templates/billing/billing.statefulset.yaml
@@ -95,7 +95,7 @@ spec:
         {{- with .Values.billing.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        args: {{ compact (list (include "deepgram-self-hosted.logFormatArg" (dict "key" "billing.logFormat" "value" .Values.billing.logFormat)) "serve" "--config" "/etc/config/billing.toml") | toJson }}
+        args: {{ compact (list (include "deepgram-self-hosted.logFormatArg" (dict "key" "billing.logFormat" "value" .Values.billing.logFormat "extraEnv" .Values.billing.extraEnv)) "serve" "--config" "/etc/config/billing.toml") | toJson }}
         resources:
           requests:
             memory: "{{ .Values.billing.resources.requests.memory }}"

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -219,7 +219,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         command: [ "impeller" ]
-        args: {{ compact (list "-v" (include "deepgram-self-hosted.logFormatArg" (dict "key" "engine.logFormat" "value" $.Values.engine.logFormat)) "serve" "/etc/config/engine.toml") | toJson }}
+        args: {{ compact (list "-v" (include "deepgram-self-hosted.logFormatArg" (dict "key" "engine.logFormat" "value" $.Values.engine.logFormat "extraEnv" $.Values.engine.extraEnv)) "serve" "/etc/config/engine.toml") | toJson }}
         resources:
           requests:
             memory: "{{ $.Values.engine.resources.requests.memory }}"

--- a/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/engine/engine.deployment.yaml
@@ -219,7 +219,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         command: [ "impeller" ]
-        args: ["-v", "serve", "/etc/config/engine.toml"]
+        args: {{ compact (list "-v" (include "deepgram-self-hosted.logFormatArg" (dict "key" "engine.logFormat" "value" $.Values.engine.logFormat)) "serve" "/etc/config/engine.toml") | toJson }}
         resources:
           requests:
             memory: "{{ $.Values.engine.resources.requests.memory }}"

--- a/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
@@ -110,7 +110,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         command: [ "hermes" ]
-        args: {{ compact (list "-v" (include "deepgram-self-hosted.logFormatArg" (dict "key" "licenseProxy.logFormat" "value" .Values.licenseProxy.logFormat)) "serve" "/etc/config/license-proxy.toml") | toJson }}
+        args: {{ compact (list "-v" (include "deepgram-self-hosted.logFormatArg" (dict "key" "licenseProxy.logFormat" "value" .Values.licenseProxy.logFormat "extraEnv" .Values.licenseProxy.extraEnv)) "serve" "/etc/config/license-proxy.toml") | toJson }}
         resources:
           requests:
             memory: "{{ .Values.licenseProxy.resources.requests.memory }}"

--- a/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
+++ b/charts/deepgram-self-hosted/templates/license-proxy/license-proxy.deployment.yaml
@@ -110,7 +110,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         command: [ "hermes" ]
-        args: ["-v", "serve", "/etc/config/license-proxy.toml"]
+        args: {{ compact (list "-v" (include "deepgram-self-hosted.logFormatArg" (dict "key" "licenseProxy.logFormat" "value" .Values.licenseProxy.logFormat)) "serve" "/etc/config/license-proxy.toml") | toJson }}
         resources:
           requests:
             memory: "{{ .Values.licenseProxy.resources.requests.memory }}"

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -492,7 +492,6 @@ api:
   # -- [Log output format](https://developers.deepgram.com/docs/log-formats)
   # for the API container. One of `full`, `compact`, `pretty`, or `json`.
   # Leave empty to use the container's own default (`full`).
-  # Requires `release-260319` or later.
   # @default -- `""`
   logFormat: ""
 
@@ -731,7 +730,6 @@ engine:
   # -- [Log output format](https://developers.deepgram.com/docs/log-formats)
   # for the Engine container. One of `full`, `compact`, `pretty`, or `json`.
   # Leave empty to use the container's own default (`full`).
-  # Requires `release-260319` or later.
   # @default -- `""`
   logFormat: ""
 
@@ -1069,7 +1067,6 @@ licenseProxy:
   # -- [Log output format](https://developers.deepgram.com/docs/log-formats)
   # for the License Proxy container. One of `full`, `compact`, `pretty`, or `json`.
   # Leave empty to use the container's own default (`full`).
-  # Requires `release-260319` or later.
   # @default -- `""`
   logFormat: ""
 
@@ -1271,7 +1268,6 @@ billing:
   # -- [Log output format](https://developers.deepgram.com/docs/log-formats)
   # for the Billing container. One of `full`, `compact`, `pretty`, or `json`.
   # Leave empty to use the container's own default (`full`).
-  # Requires `release-260319` or later.
   # @default -- `""`
   logFormat: ""
 

--- a/charts/deepgram-self-hosted/values.yaml
+++ b/charts/deepgram-self-hosted/values.yaml
@@ -489,6 +489,13 @@ api:
   #         name: my-secret
   #         key: my-key
 
+  # -- [Log output format](https://developers.deepgram.com/docs/log-formats)
+  # for the API container. One of `full`, `compact`, `pretty`, or `json`.
+  # Leave empty to use the container's own default (`full`).
+  # Requires `release-260319` or later.
+  # @default -- `""`
+  logFormat: ""
+
 engine:
   # -- namePrefix is the prefix to apply to the name of all K8s objects
   # associated with the Deepgram Engine containers.
@@ -720,6 +727,13 @@ engine:
   #       secretKeyRef:
   #         name: my-secret
   #         key: my-key
+
+  # -- [Log output format](https://developers.deepgram.com/docs/log-formats)
+  # for the Engine container. One of `full`, `compact`, `pretty`, or `json`.
+  # Leave empty to use the container's own default (`full`).
+  # Requires `release-260319` or later.
+  # @default -- `""`
+  logFormat: ""
 
   # -- Configure Engine containers to listen for requests from API containers.
   # @default -- ``
@@ -1052,6 +1066,13 @@ licenseProxy:
   #         name: my-secret
   #         key: my-key
 
+  # -- [Log output format](https://developers.deepgram.com/docs/log-formats)
+  # for the License Proxy container. One of `full`, `compact`, `pretty`, or `json`.
+  # Leave empty to use the container's own default (`full`).
+  # Requires `release-260319` or later.
+  # @default -- `""`
+  logFormat: ""
+
 # -- Configuration options for the Deepgram Billing container.
 # The Billing container is used for airgapped deployments where API and Engine
 # cannot reach license.deepgram.com. It validates licenses locally using a
@@ -1246,6 +1267,13 @@ billing:
   #       secretKeyRef:
   #         name: my-secret
   #         key: my-key
+
+  # -- [Log output format](https://developers.deepgram.com/docs/log-formats)
+  # for the Billing container. One of `full`, `compact`, `pretty`, or `json`.
+  # Leave empty to use the container's own default (`full`).
+  # Requires `release-260319` or later.
+  # @default -- `""`
+  logFormat: ""
 
 # -- Passthrough values for [NVIDIA GPU Operator Helm chart](https://github.com/NVIDIA/gpu-operator/blob/master/deployments/gpu-operator/values.yaml)
 # You may use the NVIDIA GPU Operator to manage installation of NVIDIA drivers and the container toolkit on nodes with attached GPUs.


### PR DESCRIPTION
## Summary

Deepgram containers have supported four log output formats — `full`, `compact`, `pretty`, `json` — since [release-260319](https://developers.deepgram.com/changelog/2026/3/19), but the chart had no way to select one. `--log-format` is a CLI flag with no TOML or environment-variable equivalent, and the chart hardcoded each container's `args`, so neither `customToml` nor `extraEnv` could reach it.

This adds `logFormat` to all four components:

```yaml
api:          { logFormat: json }
engine:       { logFormat: json }
licenseProxy: { logFormat: json }
billing:      { logFormat: json }
```

Accepts `full`, `compact`, `pretty`, or `json`. An unrecognized value fails at template time rather than crash-looping the pod after rollout:

```
Error: api.logFormat must be one of full, compact, pretty, json (got "jsonl")
```

The default is empty, which renders args byte-identical to before — upgrades are a no-op unless the value is set.

## Flag placement

The flag is rendered **ahead of** the `serve` subcommand:

```
["-v","--log-format=json","serve","/etc/config/api.toml"]
["--log-format=json","serve","--config","/etc/config/billing.toml"]   # billing has no -v
```

This matters. `--log-format` is a top-level option on all four binaries, not a clap global — it appears in `<binary> --help` but not `<binary> serve --help`. Appending it makes the container exit immediately:

```
error: unexpected argument '--log-format' found
```

Note that the ["Kubernetes" example on the log formats docs page](https://developers.deepgram.com/docs/log-formats) currently shows the flag appended, via an `additionalArgs` value that has never existed in this chart. That example does not work for any of the four components and should be updated separately.

## Legacy JSON environment variable

The containers also accept a legacy `JSON` environment variable that forces JSON output, reachable today via `extraEnv`. Combining it with `--log-format` set to anything other than `json` does not resolve in favor of either setting — the process panics and the pod crash-loops:

```
thread 'main' panicked at src/logging.rs:348:13:
When --json arg or JSON env variable are set, cannot set --log-format to another format
```

The second commit rejects that combination at template time. The check is deliberately narrow, matching what actually panics:

| `extraEnv` | `logFormat` | Runtime | Chart |
|---|---|---|---|
| `JSON=true` | `json` | starts | allowed |
| `JSON=true` | `full` / `compact` / `pretty` | **panic** | **rejected** |
| `JSON=false` / `1` / `0` | any | starts | allowed |
| `JSON` via `valueFrom` | any | unknowable at render time | allowed |
| unset | any | starts | allowed |

Setting `JSON=true` with no `logFormat` is untouched, so anyone already using it as a workaround is unaffected.

## Testing

Verified against `release-260812` images on a GPU instance (NVIDIA L4). All four binaries behave identically:

| | Flag in `--help` | Absent from `serve --help` | Appended → fails | Prepended → works |
|---|---|---|---|---|
| API (`stem`) | ✅ | ✅ | ✅ | ✅ |
| Engine (`impeller`) | ✅ | ✅ | ✅ | ✅ |
| License Proxy (`hermes`) | ✅ | ✅ | ✅ | ✅ |
| Billing (`athena`) | ✅ | ✅ | ✅ | ✅ |

Engine output, past GPU init so this is real runtime behavior rather than arg parsing:

```
# logFormat: json
{"timestamp":"...","level":"INFO","fields":{"message":"GPU 0 passed the boot-time matmul check.","gpu":0},"target":"impeller"}

# default (full)
2026-08-24T21:26:10Z  INFO impeller: GPU 0 passed the boot-time matmul check. gpu=0
```

Template rendering verified for: unset (byte-identical to before), each of the four formats, an invalid value, every row of the `JSON` table above across all four components, and voice-agent mode where all three Engine deployments pick up the setting. `helm lint` and `helm-docs` are clean.

## Notes

- Left as an **Unreleased** changelog entry; no chart version bump.
- Setting `logFormat` on an image older than `release-260319` fails with `unexpected argument '--log-format' found` (confirmed against `release-260212`). This is not enforced by the chart — the version requirement is documented in `values.yaml`, and the failure is immediate and self-explanatory.
- `full` and `compact` produced byte-identical output in every sample captured, across all four binaries. They diverge only when span context exists, and these startup paths open no spans.
- `pretty` additionally emits source locations (`at src/config.rs:130`), which the docs' "color highlighting" description undersells.
